### PR TITLE
Add backend entry point for hosting panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,19 @@ Este repositório contém o código-fonte do site institucional do Jaguar Center
 
 ## Configuração rápida
 
-1. Copie `.env.example` para `.env` na raiz do backend e configure as variáveis (como `PORT` e `USE_JSON_DB`).
+1. Copie `.env.example` para `.env` na raiz do backend e configure as variáveis (como `PORT` e credenciais de banco de dados).
 2. Instale as dependências no frontend e backend com `npm install`.
 3. Rode `npm run dev` no frontend e `npm start` no backend (ou `npm run dev` para usar nodemon).
 
 O frontend espera que `VITE_API_URL` esteja apontando para o endereço do backend (por padrão, `http://localhost:4000`).
+
+## Deploy
+
+Para gerar os arquivos de produção do frontend dentro da pasta do backend, utilize:
+
+```bash
+cd backend
+npm run sync:frontend
+```
+
+Esse comando executa o build do Vite e copia o resultado para `backend/dist`. Em ambientes como o Plesk, configure o arquivo de inicialização para `app.js` dentro da pasta `backend/`.

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,1 @@
+require('./src/server');

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,9 +2,11 @@
   "name": "jaguar-center-plaza-backend",
   "version": "1.0.0",
   "private": true,
+  "main": "app.js",
   "scripts": {
-    "dev": "nodemon src/server.js",
-    "start": "node src/server.js"
+    "dev": "nodemon app.js",
+    "start": "node app.js",
+    "sync:frontend": "node ../scripts/build-and-sync.mjs"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,7 +3,8 @@
 Este diretório reserva espaço para scripts de publicação futura. O fluxo recomendado consiste em:
 
 1. Rodar `npm run build` dentro de `frontend/` para gerar `frontend/dist`.
-2. Executar `npm run prestart` dentro de `backend/` para sincronizar o build com `backend/dist`.
-3. Publicar o conteúdo da pasta `backend/` no servidor Node.js desejado.
+2. Executar `npm run sync:frontend` dentro de `backend/` para sincronizar o build com `backend/dist`.
+3. Publicar o conteúdo da pasta `backend/` no servidor Node.js desejado. Configure o arquivo de inicialização (`app.js`) no painel da hospedagem.
 
-Caso o ambiente utilize Plesk ou hospedagem estática, copie os arquivos de `backend/dist` para o diretório público e mantenha o backend como API dedicada.
+Caso o ambiente utilize Plesk ou hospedagem estática, copie os arquivos de `backend/dist` para o diretório público e mantenha o
+backend como API dedicada.


### PR DESCRIPTION
## Summary
- add a top-level backend entry point compatible with hosting panels such as Plesk
- update backend scripts and documentation to explain the new startup file and frontend sync process

## Testing
- npm run sync:frontend (backend)


------
https://chatgpt.com/codex/tasks/task_e_68e066e8dcb88330aba3357b3fda3742