### PR TITLE
Add backend entry point and default route

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,1 @@
+require('./src/server');

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -27,6 +27,10 @@ app.use(cors());
 app.use(express.json());
 app.use(morgan('dev'));
 
+app.get('/', (_req, res) => {
+  res.type('text').send('JaguarPlaza API\n- /api/health\n- /api/tables\n- /api/lojas');
+});
+
 app.use('/api', apiRoutes);
 
 app.use(errorHandler);


### PR DESCRIPTION
## Summary
- add an index.js startup file that simply boots the existing server
- expose a default `/` route in the backend to provide basic API information

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e06b7f478c83309aeedc6222b2dcc0