### PR TITLE
Make frontend build optional and sanitize backend configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,23 @@ O fluxo de publicação segue o mesmo padrão adotado pelos demais projetos hosp
 | **URL do aplicativo** | `/api`                    |
 | **Arquivo inicial**   | `app.js`                  |
 
-Variáveis de ambiente necessárias:
+Variáveis de ambiente necessárias (defina no arquivo `backend/.env`):
 
 ```
-DB_HOST=127.0.0.1
-DB_PORT=3306
-DB_USER=Winove-center-plaza
-DB_PASSWORD=<sua_senha>
-DB_NAME=JaguarPlaza
+DB_HOST=<host_do_banco>
+DB_PORT=<porta_do_banco>
+DB_USER=<usuario_do_banco>
+DB_PASSWORD=<senha_do_banco>
+DB_NAME=<nome_da_base>
+# Opcional: porta local quando executado fora do Plesk
+PORT=3333
+# Opcional: servir o build do frontend diretamente pela API
+SERVE_FRONTEND=true
+# Opcional: caminho (relativo ao backend) do build do frontend
+FRONTEND_DIST=../dist
 ```
+
+Para cenários em que apenas a API deve ser executada (sem build ou entrega do frontend), defina a variável de ambiente `SKIP_FRONTEND_BUILD=1` ao rodar o script `npm run --prefix backend sync:frontend` ou simplesmente não execute esse script. Também é possível desabilitar completamente a entrega de arquivos estáticos pela API configurando `SERVE_FRONTEND=false`.
 
 > **Importante:** não defina a variável `PORT`. O Plesk controla automaticamente a porta utilizada pela aplicação Node.js.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,8 @@
-DB_HOST=lweb03.appuni.com.br
+DB_HOST=127.0.0.1
 DB_PORT=3306
-DB_USER=winove
-DB_PASSWORD=9*19avmU0
-DB_NAME=fernando_winove_com_br_
+DB_USER=seu_usuario
+DB_PASSWORD=sua_senha
+DB_NAME=sua_base_de_dados
 PORT=3333
+# SERVE_FRONTEND=true
+# FRONTEND_DIST=../dist


### PR DESCRIPTION
## Summary
- allow skipping the frontend build-and-sync step when running in backend-only environments
- make static asset serving optional in the Express server and configurable via environment variables
- replace hard-coded database credentials with placeholders in the sample env file and documentation

## Testing
- SKIP_FRONTEND_BUILD=1 npm --prefix backend run sync:frontend
- SERVE_FRONTEND=false PORT=4001 node backend/app.js

------
https://chatgpt.com/codex/tasks/task_e_68e0f8b0d4dc8330bfd14fe0bd8ed772