### PR TITLE
Fix frontend API list parsing for paginated responses

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -199,9 +199,33 @@ export async function getTables() {
   return response.data.tables;
 }
 
+type MaybePaginatedResponse<Row> =
+  | Row[]
+  | {
+      data?: Row[];
+      pagination?: {
+        page?: number;
+        limit?: number;
+        total?: number;
+        totalPages?: number;
+      } | null;
+    };
+
+function ensureRowArray<Row>(payload: MaybePaginatedResponse<Row>): Row[] {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (payload && Array.isArray(payload.data)) {
+    return payload.data;
+  }
+
+  return [];
+}
+
 export async function getList(table: TableName) {
-  const response = await api.get<Record<string, unknown>[]>(`/${table}`);
-  return response.data;
+  const response = await api.get<MaybePaginatedResponse<Record<string, unknown>>>(`/${table}`);
+  return ensureRowArray(response.data);
 }
 
 export async function getById(table: TableName, id: string) {


### PR DESCRIPTION
## Summary
- normalize frontend API client responses so table queries return arrays even when wrapped in pagination metadata
- keep company category fetching working with backend pagination output to restore dynamic listings

## Testing
- npm run build:frontend

------
https://chatgpt.com/codex/tasks/task_e_68e1087616388330ac9765b55e257834