### PR TITLE
Fix frontend sync workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 frontend/node_modules/
 backend/node_modules/
 backend/.env
+backend/public/
 *.log
 .env
 backend/dist/

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,7 +19,7 @@ Este diretório reserva espaço para scripts de publicação futura. O fluxo rec
    fi
 
    cd ..
-   npm run --prefix backend sync:frontend
+   npm run sync:frontend
    ```
 
 5. Após o deploy, clique em **Reiniciar aplicativo** no painel Node.js para aplicar as atualizações imediatamente.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "nodemon backend/app.js",
     "test": "npm --prefix frontend run lint",
     "build:frontend": "npm --prefix frontend run build",
-    "sync:frontend": "npm run build:frontend && cp -r frontend/dist backend/public || true"
+    "sync:frontend": "npm run build:frontend && node ./scripts/sync-frontend.mjs"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/scripts/sync-frontend.mjs
+++ b/scripts/sync-frontend.mjs
@@ -1,0 +1,36 @@
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs/promises';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const sourceDir = path.join(rootDir, 'frontend', 'dist');
+const targetDir = path.join(rootDir, 'backend', 'public');
+
+async function ensureSourceExists() {
+  try {
+    await fs.access(sourceDir);
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new Error(
+        `Diretório de build do frontend não encontrado em ${sourceDir}. ` +
+          'Execute "npm run build:frontend" antes de sincronizar.'
+      );
+    }
+
+    throw error;
+  }
+}
+
+async function syncFrontend() {
+  await ensureSourceExists();
+  await fs.rm(targetDir, { recursive: true, force: true });
+  await fs.mkdir(targetDir, { recursive: true });
+  await fs.cp(sourceDir, targetDir, { recursive: true });
+}
+
+syncFrontend().catch((error) => {
+  console.error('Falha ao sincronizar build do frontend:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- replace the shell copy used by `sync:frontend` with a node script that fully refreshes `backend/public`
- ignore generated frontend artifacts and fix the deploy readme instructions to run the correct sync command

## Testing
- npm test
- npm run sync:frontend

------
https://chatgpt.com/codex/tasks/task_e_68e16fa091588330ab5b86f095f9ec1e