### PR TITLE
Revamp home page with category support

### DIFF
--- a/frontend/public/assets/categories-fallback.json
+++ b/frontend/public/assets/categories-fallback.json
@@ -1,0 +1,45 @@
+{
+  "categories": [
+    {
+      "id": "servicos-corporativos",
+      "name": "Serviços corporativos",
+      "description": "Contabilidade, advocacia, tecnologia e consultorias preparadas para apoiar o crescimento das empresas.",
+      "companies": [
+        { "id": "contato-digital", "name": "Contato Digital" },
+        { "id": "atlas-contabilidade", "name": "Atlas Contabilidade" },
+        { "id": "plaza-tech", "name": "Plaza Tech Solutions" }
+      ]
+    },
+    {
+      "id": "saude-bem-estar",
+      "name": "Saúde & bem-estar",
+      "description": "Clínicas médicas, odontológicas, pilates, fisioterapia e terapias integrativas em ambientes acolhedores.",
+      "companies": [
+        { "id": "clinica-integrada", "name": "Clínica Integrada" },
+        { "id": "studio-pilates", "name": "Studio Pilates Plaza" },
+        { "id": "odontologia-plaza", "name": "Odontologia Plaza" }
+      ]
+    },
+    {
+      "id": "gastronomia-conveniencia",
+      "name": "Gastronomia & conveniência",
+      "description": "Restaurantes, cafeterias, mercado e opções rápidas para quem precisa praticidade no dia a dia.",
+      "companies": [
+        { "id": "cafe-jaguar", "name": "Café Jaguar" },
+        { "id": "emporio-centro", "name": "Empório do Centro" },
+        { "id": "praca-sabores", "name": "Praça Sabores" }
+      ]
+    },
+    {
+      "id": "beleza-estetica",
+      "name": "Beleza & estética",
+      "description": "Centros de estética, salões e barbearias com serviços premium e profissionais especializados.",
+      "companies": [
+        { "id": "studio-beleza", "name": "Studio Beleza" },
+        { "id": "spa-jaguar", "name": "Spa Jaguar" },
+        { "id": "barbearia-plaza", "name": "Barbearia Plaza" }
+      ]
+    }
+  ],
+  "generatedAt": "2024-01-01T00:00:00.000Z"
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -32,6 +32,23 @@ export interface AreasResponse {
   generatedAt?: string;
 }
 
+export interface CompanySummary {
+  id: string;
+  name: string;
+}
+
+export interface CompanyCategory {
+  id: string;
+  name: string;
+  description?: string;
+  companies: CompanySummary[];
+}
+
+export interface CategoriesResponse {
+  categories: CompanyCategory[];
+  generatedAt?: string;
+}
+
 export interface LibrasLeadPayload {
   name: string;
   email: string;
@@ -42,6 +59,7 @@ export interface LibrasLeadPayload {
 }
 
 const AREAS_FALLBACK = '/assets/areas-fallback.json';
+const CATEGORIES_FALLBACK = '/assets/categories-fallback.json';
 
 export async function fetchAreas(): Promise<AreasResponse> {
   try {
@@ -50,6 +68,16 @@ export async function fetchAreas(): Promise<AreasResponse> {
   } catch (error) {
     console.warn('Falha ao buscar áreas, usando fallback.', error);
     return fetchFallbackJson<AreasResponse>(AREAS_FALLBACK);
+  }
+}
+
+export async function fetchCategories(): Promise<CategoriesResponse> {
+  try {
+    const response = await api.get<CategoriesResponse>('/categories');
+    return response.data;
+  } catch (error) {
+    console.warn('Falha ao buscar categorias, usando fallback.', error);
+    return fetchFallbackJson<CategoriesResponse>(CATEGORIES_FALLBACK);
   }
 }
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,30 +1,15 @@
-import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import Container from '../components/layout/Container';
-import { fetchAreas } from '../lib/api';
-import { formatFieldLabel, formatFieldValue } from '../lib/format';
+import { fetchCategories, type CompanyCategory } from '../lib/api';
 import { useSEO } from '../hooks/useSEO';
-
-const heroHighlights = [
-  'Ambientes empresariais, consultórios, lojas e conveniências em um único endereço.',
-  'Infraestrutura com estacionamento, acessibilidade, facilities e monitoramento 24h.',
-  'Localização privilegiada no coração de Jaguariúna com fácil acesso às principais vias.'
-];
 
 const featureItems = [
   {
-    title: 'Salas prontas para operar',
-    description: 'Espaços moduláveis com climatização, cabeamento estruturado e apoio técnico para todos os segmentos.',
+    title: 'Salas comerciais',
+    description: 'Estruturas moduláveis, climatizadas e com segurança patrimonial 24h para receber o seu negócio.',
     icon: (
-      <svg
-        aria-hidden
-        className="h-8 w-8 text-primary-600"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        viewBox="0 0 24 24"
-      >
+      <svg aria-hidden className="h-7 w-7 text-primary-600" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
         <path d="M4 21h16" strokeLinecap="round" />
         <path d="M6 21V5a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v16" />
         <rect x="9" y="9" width="2" height="2" fill="currentColor" stroke="none" />
@@ -35,17 +20,10 @@ const featureItems = [
     )
   },
   {
-    title: 'Saúde e bem-estar integrados',
-    description: 'Consultórios acessíveis, recepções compartilhadas e infraestrutura para exames e terapias.',
+    title: 'Clínicas & saúde',
+    description: 'Ambientes preparados para consultórios, laboratórios e serviços de bem-estar com acessibilidade total.',
     icon: (
-      <svg
-        aria-hidden
-        className="h-8 w-8 text-primary-600"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        viewBox="0 0 24 24"
-      >
+      <svg aria-hidden className="h-7 w-7 text-primary-600" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
         <path d="M12 2a7 7 0 0 0-7 7c0 4.5 7 13 7 13s7-8.5 7-13a7 7 0 0 0-7-7z" />
         <path d="M12 8v4" strokeLinecap="round" />
         <path d="M10 10h4" strokeLinecap="round" />
@@ -53,211 +31,214 @@ const featureItems = [
     )
   },
   {
-    title: 'Gastronomia e conveniência',
-    description: 'Restaurantes, cafés, serviços públicos e facilidades para quem trabalha ou visita o complexo.',
+    title: 'Beleza & estética',
+    description: 'Salões, barbearias, spas e centros de estética reunidos para quem busca experiências completas.',
     icon: (
-      <svg
-        aria-hidden
-        className="h-8 w-8 text-primary-600"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        viewBox="0 0 24 24"
-      >
-        <path d="M6 3h12" strokeLinecap="round" />
-        <path d="M6 8h12" strokeLinecap="round" />
-        <path d="M6 13h12" strokeLinecap="round" />
-        <path d="M4 3v10a4 4 0 0 0 4 4h8a4 4 0 0 0 4-4V3" />
+      <svg aria-hidden className="h-7 w-7 text-primary-600" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+        <path d="M4 16c4-4 7-9 7-13" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M10 7c0 5.523-3.582 10-8 10 1.724 2.354 4.527 4 7.5 4 5.523 0 10-4.03 10-9 0-2.876-1.58-5.395-4-6.903" />
       </svg>
     )
   },
   {
-    title: 'Ambiente seguro e acolhedor',
-    description: 'Controle de acesso, limpeza, manutenção predial e suporte operacional especializado.',
+    title: 'Serviços essenciais',
+    description: 'Lotéricas, bancos, cartórios, alimentação e facilidades do dia a dia em um só endereço.',
     icon: (
-      <svg
-        aria-hidden
-        className="h-8 w-8 text-primary-600"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        viewBox="0 0 24 24"
-      >
-        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-        <path d="M9 11l2 2 4-4" strokeLinecap="round" strokeLinejoin="round" />
+      <svg aria-hidden className="h-7 w-7 text-primary-600" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+        <path d="M3 5h18M5 5v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V5" />
+        <path d="M9 9h6" strokeLinecap="round" />
+        <path d="M12 9v8" strokeLinecap="round" />
       </svg>
     )
-  }
-];
-
-const comfortHighlights = [
-  {
-    title: 'Recepção centralizada',
-    description: 'Atendimento qualificado, triagem e apoio a visitantes para cada segmento do empreendimento.'
-  },
-  {
-    title: 'Infraestrutura completa',
-    description: 'Estacionamento, elevadores inteligentes, climatização, segurança e manutenção em tempo integral.'
-  },
-  {
-    title: 'Ambientes flexíveis',
-    description: 'Salas que se adaptam a diferentes tamanhos de operação com possibilidade de expansão modular.'
-  }
-];
-
-const servicesHighlights = [
-  {
-    title: '+180 empresas e serviços',
-    description: 'Negócios que movimentam a economia da região e oferecem soluções para toda a cidade.'
-  },
-  {
-    title: '10 segmentos especializados',
-    description: 'Administração, saúde, beleza, gastronomia, advocacia, coworking e muitos outros setores reunidos.'
-  },
-  {
-    title: 'Endereço estratégico',
-    description: 'Rua Amazonas, 504 · Centro de Jaguariúna — acesso rápido às principais vias e transporte público.'
   }
 ];
 
 const quickInfos = [
-  { label: 'Horário de funcionamento', value: 'Segunda a sexta: 8h às 20h · Sábado: 8h às 14h' },
-  { label: 'Telefone', value: '(19) 3833-5600' },
-  { label: 'E-mail', value: 'contato@jaguarcenterplaza.com.br' }
+  { label: 'Horário de funcionamento', value: 'Seg. a sex. das 8h às 20h · Sáb. das 8h às 14h' },
+  { label: 'Endereço', value: 'Rua Amazonas, 504 · Centro · Jaguariúna' },
+  { label: 'Telefone', value: '(19) 3833-5600' }
 ];
 
+type CategoryCard = {
+  title: string;
+  description: string;
+  companiesLabel: string;
+  image: string;
+};
+
+const fallbackCategoryCards: CategoryCard[] = [
+  {
+    title: 'Serviços corporativos',
+    description: 'Contabilidade, advocacia, tecnologia e consultorias preparadas para apoiar o crescimento das empresas.',
+    companiesLabel: '18 empresas',
+    image: '/Fachada.jpg'
+  },
+  {
+    title: 'Saúde & bem-estar',
+    description: 'Clínicas médicas, odontológicas, pilates, fisioterapia e terapias integrativas em ambientes acolhedores.',
+    companiesLabel: '12 empresas',
+    image: '/Fachada3.jpg'
+  },
+  {
+    title: 'Gastronomia & conveniência',
+    description: 'Restaurantes, cafeterias, mercado e opções rápidas para quem precisa praticidade no dia a dia.',
+    companiesLabel: '9 empresas',
+    image: '/Fachada4.jpg'
+  },
+  {
+    title: 'Beleza & estética',
+    description: 'Centros de estética, salões e barbearias com serviços premium e profissionais especializados.',
+    companiesLabel: '15 empresas',
+    image: '/Fachada5.jpg'
+  }
+];
+
+const newsPosts = [
+  {
+    title: 'Campanha do Agasalho 2024 no Jaguar Center Plaza',
+    date: '12 de junho de 2024',
+    excerpt: 'Junte-se a nós na arrecadação de cobertores e agasalhos em parceria com as instituições sociais da cidade.',
+    image: '/333984251_205311685379957_6835703374332389472_n.jpg'
+  },
+  {
+    title: 'Feira de Negócios e Networking com empresas residentes',
+    date: '28 de maio de 2024',
+    excerpt: 'Uma tarde para conectar empreendedores, fornecedores e investidores com palestras e rodadas de negócios.',
+    image: '/333674171_999380511025032_54232673152881839_n.jpg'
+  },
+  {
+    title: 'Oficinas de qualidade de vida para colaboradores',
+    date: '15 de abril de 2024',
+    excerpt: 'Programação com aulas de yoga, acompanhamento nutricional e palestras sobre saúde mental no auditório.',
+    image: '/img-jaguar-center-plaza-001-768x460.jpg'
+  }
+];
+
+function formatCompaniesLabel(count: number) {
+  if (count === 1) {
+    return '1 empresa';
+  }
+
+  return `${count} empresas`;
+}
+
 export default function HomePage() {
-  const query = useQuery({ queryKey: ['areas'], queryFn: fetchAreas });
+  const { data, isLoading, isError } = useQuery({ queryKey: ['categories'], queryFn: fetchCategories });
+  const categories = data?.categories ?? [];
 
   useSEO({
-    title: 'Jaguar Center Plaza — Seu polo de serviços em Jaguariúna',
+    title: 'Jaguar Center Plaza — Tudo para o seu conforto e bem-estar',
     description:
-      'Empreendimento multiuso com salas comerciais, consultórios, gastronomia e serviços essenciais. Conheça as categorias disponíveis e agende sua visita.',
+      'Conheça o Jaguar Center Plaza, um shopping corporativo com serviços de administração, advocacia, beleza, contabilidade, saúde, imóveis, indústrias e serviços públicos. Shopping corporativo de Jaguariúna com empresas de serviços, saúde, gastronomia, estética e conveniência em um único endereço.',
     canonical: 'https://www.jaguarcenterplaza.com.br/'
   });
 
-  const areas = query.data?.items ?? [];
-  const areaHighlights = useMemo(() => areas.slice(0, 6), [areas]);
+  const categoryImages = ['/Fachada.jpg', '/Fachada3.jpg', '/Fachada4.jpg', '/Fachada5.jpg'];
+  const dynamicCategoryCards: CategoryCard[] = categories.slice(0, 4).map((category: CompanyCategory, index) => ({
+    title: category.name,
+    description:
+      category.description?.trim()?.length
+        ? category.description
+        : 'Conheça o mix de empresas que oferecem serviços completos para o seu dia a dia.',
+    companiesLabel: formatCompaniesLabel(category.companies?.length ?? 0),
+    image: categoryImages[index % categoryImages.length]
+  }));
+
+  const categoryCards: CategoryCard[] = dynamicCategoryCards.length > 0 ? dynamicCategoryCards : fallbackCategoryCards;
 
   return (
     <div className="space-y-24 pb-24">
-      <section className="bg-gradient-to-b from-[#0b4f6c] to-[#16607e] py-20 text-white">
-        <Container className="grid gap-12 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
-          <div className="space-y-8">
-            <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-sm font-semibold uppercase tracking-[0.3em]">
+      <section className="relative isolate overflow-hidden">
+        <img src="/Fachada.jpg" alt="Fachada do Jaguar Center Plaza" className="absolute inset-0 h-full w-full object-cover" />
+        <div className="absolute inset-0 bg-gradient-to-r from-[#0b4f6c]/80 via-[#1d6b4c]/75 to-primary-700/75" aria-hidden />
+        <div className="absolute -left-24 top-1/3 h-72 w-72 -translate-y-1/2 rounded-full bg-accent-400/40 blur-3xl" aria-hidden />
+        <div className="absolute -right-20 bottom-0 h-80 w-80 translate-y-1/3 rounded-full bg-primary-500/40 blur-3xl" aria-hidden />
+
+        <Container className="relative z-10 grid gap-12 py-24 lg:grid-cols-[minmax(0,1fr)_minmax(0,380px)] lg:items-center">
+          <div className="space-y-6 text-white">
+            <p className="inline-flex items-center rounded-full bg-white/15 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em]">
               Jaguar Center Plaza
-            </span>
-            <div className="space-y-5">
-              <h1 className="text-4xl font-semibold leading-tight sm:text-5xl">
-                Seu polo de serviços, saúde, gastronomia e negócios em Jaguariúna
-              </h1>
-              <p className="text-lg text-white/80">
-                Tudo o que sua empresa precisa para prosperar: infraestrutura moderna, atendimento integrado e uma comunidade de negócios que cresce junto com a cidade.
-              </p>
-            </div>
-            <ul className="space-y-3 text-base text-white/80">
-              {heroHighlights.map((item) => (
-                <li key={item} className="flex items-start gap-3">
-                  <span className="mt-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-accent-400/20 text-accent-200">
-                    <svg aria-hidden className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                      <path d="M5 13l4 4L19 7" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
-                  </span>
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
+            </p>
+            <h1 className="text-4xl font-bold leading-tight sm:text-5xl">
+              O destino completo para conectar negócios e experiências memoráveis
+            </h1>
+            <p className="text-lg text-white/80">
+              Somos o primeiro shopping corporativo da região com um ecossistema que integra soluções empresariais, conveniência, saúde e bem-estar em um único endereço estratégico.
+            </p>
+            <p className="text-lg text-white/80">
+              Um ambiente completo para empresas, profissionais e visitantes com infraestrutura moderna, segurança, conforto e eventos o ano inteiro.
+            </p>
             <div className="flex flex-wrap gap-4">
               <Link
-                to="/salas"
-                className="inline-flex items-center rounded-full bg-accent-400 px-6 py-3 text-sm font-semibold text-[#0b4f6c] shadow-sm transition hover:bg-accent-300"
+                to="/empresas"
+                className="inline-flex items-center rounded-full bg-accent-500 px-6 py-3 text-sm font-semibold text-white shadow-lg transition-colors hover:bg-accent-400"
               >
-                Conheça as salas disponíveis
+                Conheça as empresas
               </Link>
               <Link
                 to="/contato"
-                className="inline-flex items-center rounded-full border border-white/40 px-6 py-3 text-sm font-semibold text-white transition hover:border-white hover:bg-white/10"
+                className="inline-flex items-center rounded-full border border-white/70 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/10"
               >
-                Quero agendar uma visita
+                Agende uma visita
               </Link>
             </div>
-          </div>
-          <div className="rounded-3xl bg-white/10 p-8 backdrop-blur">
-            <h2 className="text-lg font-semibold">Informações rápidas</h2>
-            <p className="mt-2 text-sm text-white/70">
-              Estamos prontos para receber sua operação com atendimento personalizado e infraestrutura completa.
-            </p>
-            <ul className="mt-6 space-y-4 text-sm text-white/80">
+            <div className="grid gap-4 pt-4 sm:grid-cols-3">
               {quickInfos.map((info) => (
-                <li key={info.label} className="flex flex-col gap-1">
-                  <span className="text-xs font-semibold uppercase tracking-[0.3em] text-accent-200">{info.label}</span>
-                  <span>{info.value}</span>
-                </li>
+                <div key={info.label} className="rounded-2xl bg-white/15 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-accent-100">{info.label}</p>
+                  <p className="mt-1 text-sm font-medium text-white">{info.value}</p>
+                </div>
               ))}
-            </ul>
-            <div className="mt-6 rounded-2xl bg-white/5 p-4 text-sm text-white/70">
-              Rua Amazonas, 504 · Centro · Jaguariúna · SP
             </div>
           </div>
-        </Container>
-      </section>
-
-      <section>
-        <Container className="space-y-10">
-          <div className="max-w-3xl space-y-4">
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-primary-500">Tudo para o seu conforto</p>
-            <h2 className="section-title text-primary-900">Ambientes pensados para bem-estar e produtividade</h2>
-            <p className="section-subtitle">
-              Do primeiro atendimento ao pós-venda, o Jaguar Center Plaza oferece infraestrutura completa para empresas, profissionais de saúde, serviços públicos, lojas e operações de conveniência.
-            </p>
-          </div>
-          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-            {featureItems.map((feature) => (
-              <div key={feature.title} className="flex h-full flex-col gap-4 rounded-3xl border border-primary-100 bg-white p-6 shadow-sm">
-                <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary-50">{feature.icon}</span>
-                <h3 className="text-xl font-semibold text-primary-800">{feature.title}</h3>
-                <p className="text-sm text-[#4f5d55]">{feature.description}</p>
-              </div>
-            ))}
-          </div>
-        </Container>
-      </section>
-
-      <section className="bg-white py-20">
-        <Container className="grid gap-12 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
           <div className="space-y-6">
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-primary-500">Estrutura completa</p>
-            <h2 className="section-title text-primary-900">Tudo para o seu conforto e bem-estar</h2>
-            <p className="section-subtitle">
-              Recepção trilíngue, estacionamento com valet, espaços para eventos, internet de alta velocidade e suporte operacional garantem a melhor experiência para clientes e equipes.
-            </p>
-            <ul className="grid gap-4 sm:grid-cols-2">
-              {comfortHighlights.map((item) => (
-                <li key={item.title} className="rounded-2xl border border-primary-100 bg-[#f4f6f1] p-5">
-                  <h3 className="text-lg font-semibold text-primary-800">{item.title}</h3>
-                  <p className="mt-2 text-sm text-[#4f5d55]">{item.description}</p>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className="space-y-6">
-            <div className="rounded-3xl border border-primary-100 bg-[#f4f6f1] p-8 shadow-sm">
-              <h3 className="text-xl font-semibold text-primary-800">Sempre em movimento</h3>
+            <div className="rounded-3xl bg-white/90 p-8 text-primary-800 shadow-xl backdrop-blur">
+              <h2 className="text-xl font-semibold">Tudo para o seu conforto e bem-estar</h2>
               <p className="mt-3 text-sm text-[#4f5d55]">
-                Eventos corporativos, workshops, ativações de marcas e encontros promovem networking e ampliam as oportunidades de negócios.
+                Salas comerciais, clínicas, laboratórios, escritórios, gastronomia, conveniência, beleza e serviços públicos em um só endereço.
               </p>
-              <Link
-                to="/contato"
-                className="mt-6 inline-flex items-center rounded-full bg-accent-500 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-accent-400"
-              >
-                Fale com a nossa equipe
-              </Link>
+              <div className="mt-6 space-y-4">
+                {featureItems.slice(0, 2).map((feature) => (
+                  <div key={feature.title} className="flex items-start gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary-100 text-primary-700">
+                      {feature.icon}
+                    </div>
+                    <div>
+                      <p className="text-sm font-semibold text-primary-800">{feature.title}</p>
+                      <p className="text-xs text-[#4f5d55]">{feature.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-8 rounded-2xl bg-primary-50 p-5 text-sm text-primary-700">
+                <p className="font-semibold">Estacionamento com 600 vagas e monitoramento 24h.</p>
+                <p className="mt-1 text-xs text-primary-600">Acesso fácil pelas principais vias de Jaguariúna e região metropolitana de Campinas.</p>
+              </div>
             </div>
-            <div className="grid gap-4 sm:grid-cols-3">
-              {servicesHighlights.map((item) => (
-                <div key={item.title} className="rounded-3xl border border-primary-100 bg-white p-6 text-sm text-[#4f5d55] shadow-sm">
-                  <span className="text-lg font-semibold text-primary-800">{item.title}</span>
-                  <p className="mt-2">{item.description}</p>
+          </div>
+        </Container>
+      </section>
+
+      <section className="-mt-16 lg:-mt-20">
+        <Container>
+          <div className="rounded-3xl bg-white p-10 shadow-xl">
+            <div className="mx-auto max-w-3xl text-center">
+              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent-500">Aqui você encontra</p>
+              <h2 className="mt-3 text-3xl font-bold text-primary-800 sm:text-4xl">Tudo para o seu conforto e bem-estar</h2>
+              <p className="mt-4 text-base text-[#4f5d55]">
+                Um mix completo de soluções para quem busca praticidade, networking e qualidade de vida no mesmo lugar.
+              </p>
+            </div>
+            <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+              {featureItems.map((feature) => (
+                <div key={feature.title} className="flex flex-col gap-4 rounded-2xl bg-[#f4f6f1] p-6 shadow-sm">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary-100 text-primary-700">
+                    {feature.icon}
+                  </div>
+                  <div>
+                    <h3 className="text-lg font-semibold text-primary-800">{feature.title}</h3>
+                    <p className="mt-2 text-sm text-[#4f5d55]">{feature.description}</p>
+                  </div>
                 </div>
               ))}
             </div>
@@ -265,104 +246,138 @@ export default function HomePage() {
         </Container>
       </section>
 
-      <section>
-        <Container className="space-y-10">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-            <div className="max-w-3xl space-y-4">
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-primary-500">Categorias de salas</p>
-              <h2 className="section-title text-primary-900">Conheça os segmentos disponíveis no Jaguar Center Plaza</h2>
-              <p className="section-subtitle">
-                As categorias abaixo são carregadas diretamente do banco de dados e representam as oportunidades reais para instalação da sua empresa. Clique para ver todos os detalhes de cada área.
-              </p>
-            </div>
-            <Link
-              to="/salas"
-              className="inline-flex h-fit items-center rounded-full border border-primary-200 px-5 py-2 text-sm font-semibold text-primary-700 transition hover:border-primary-400 hover:text-primary-600"
-            >
-              Ver todas as salas
-            </Link>
+      <section id="empresas">
+        <Container className="space-y-12">
+          <div className="max-w-3xl space-y-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent-500">Empresas por setor</p>
+            <h2 className="text-3xl font-bold text-primary-800 sm:text-4xl">Jaguar Center Plaza é o endereço dos principais serviços da cidade</h2>
+            <p className="text-base text-[#4f5d55]">
+              Mais de 70 empresas dos segmentos corporativo, saúde, estética, gastronomia e conveniência prontas para atender você e sua empresa.
+            </p>
           </div>
 
-          {query.isLoading && <p className="text-sm text-[#4f5d55]">Carregando categorias diretamente do banco de dados...</p>}
-          {query.isError && !query.isLoading && (
-            <p className="text-sm text-red-600">Não foi possível carregar as categorias agora. Tente novamente em instantes.</p>
+          {isLoading && (
+            <div className="rounded-3xl bg-white p-6 shadow-lg">
+              <p className="text-sm text-[#4f5d55]">Carregando categorias...</p>
+            </div>
           )}
 
-          <div className="grid gap-6 lg:grid-cols-2">
-            {areaHighlights.map((area) => {
-              const records = area.records.slice(0, 2);
+          {isError && !isLoading && (
+            <div className="rounded-3xl bg-red-50 p-6 shadow-lg">
+              <p className="text-sm text-red-600">Não foi possível carregar as categorias agora. Tente novamente em instantes.</p>
+            </div>
+          )}
 
-              return (
-                <article key={area.id} className="flex h-full flex-col gap-5 rounded-3xl border border-primary-100 bg-white p-6 shadow-sm">
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between gap-3">
-                      <h3 className="text-2xl font-semibold text-primary-900">{area.name}</h3>
-                      <Link to={`/salas#${area.slug || area.id}`} className="text-sm font-semibold text-accent-500 hover:text-accent-400">
-                        Ver detalhes
-                      </Link>
-                    </div>
-                    {area.description && <p className="text-sm text-[#4f5d55]">{area.description}</p>}
-                  </div>
+          {!isLoading && categories.length === 0 && !isError && (
+            <div className="rounded-3xl bg-white p-6 shadow-lg">
+              <p className="text-sm text-[#4f5d55]">Nenhuma categoria cadastrada no momento.</p>
+            </div>
+          )}
 
-                  {records.length === 0 ? (
-                    <p className="text-sm text-[#4f5d55]">
-                      Em breve adicionaremos mais detalhes desta categoria. Entre em contato para reservar sua sala.
-                    </p>
-                  ) : (
-                    <div className="space-y-4">
-                      {records.map((record) => {
-                        const fieldEntries = Object.entries(record.fields).slice(0, 4);
-
-                        return (
-                          <div key={record.id} className="rounded-2xl bg-[#f4f6f1] p-5">
-                            <h4 className="text-lg font-semibold text-primary-800">{record.name}</h4>
-                            {fieldEntries.length > 0 ? (
-                              <dl className="mt-3 space-y-2 text-sm text-[#4f5d55]">
-                                {fieldEntries.map(([key, value]) => (
-                                  <div key={key} className="flex gap-2">
-                                    <dt className="min-w-[120px] text-xs font-semibold uppercase tracking-[0.2em] text-primary-500">
-                                      {formatFieldLabel(key)}
-                                    </dt>
-                                    <dd>{formatFieldValue(value)}</dd>
-                                  </div>
-                                ))}
-                              </dl>
-                            ) : (
-                              <p className="mt-3 text-sm text-[#4f5d55]">Entre em contato para conhecer a configuração completa desta sala.</p>
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </article>
-              );
-            })}
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+            {categoryCards.map((card) => (
+              <article key={card.title} className="flex h-full flex-col overflow-hidden rounded-3xl bg-white shadow-lg">
+                <div className="relative h-44 w-full overflow-hidden">
+                  <img src={card.image} alt={card.title} className="h-full w-full object-cover" />
+                  <span className="absolute left-4 top-4 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-primary-700">
+                    {card.companiesLabel}
+                  </span>
+                </div>
+                <div className="flex flex-1 flex-col gap-3 p-6">
+                  <h3 className="text-xl font-semibold text-primary-800">{card.title}</h3>
+                  <p className="flex-1 text-sm text-[#4f5d55]">{card.description}</p>
+                  <Link
+                    to="/empresas"
+                    className="inline-flex items-center text-sm font-semibold text-primary-600 transition-colors hover:text-accent-500"
+                  >
+                    Ver empresas
+                  </Link>
+                </div>
+              </article>
+            ))}
           </div>
         </Container>
       </section>
 
-      <section className="bg-gradient-to-r from-[#0b4f6c] via-[#145b77] to-[#1d6b88] py-16 text-white">
-        <Container className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
-          <div className="space-y-4">
-            <h2 className="text-3xl font-semibold sm:text-4xl">Pronto para fazer parte do Jaguar Center Plaza?</h2>
-            <p className="max-w-2xl text-lg text-white/80">
-              Agende uma visita guiada, conheça as categorias disponíveis e descubra como podemos adaptar um espaço sob medida para a sua operação.
+      <section className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-primary-700 via-primary-600 to-primary-500 py-16">
+        <Container className="relative z-10 grid gap-12 lg:grid-cols-2 lg:items-center">
+          <div className="space-y-4 text-white">
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent-200">Eventos corporativos</p>
+            <h2 className="text-3xl font-bold sm:text-4xl">Auditórios, salas de reunião e espaços para ativações</h2>
+            <p className="text-base text-white/80">
+              Rooftop com vista panorâmica, áreas modulares para treinamentos, lounges corporativos e suporte especializado em produção de eventos.
             </p>
-          </div>
-          <div className="flex flex-wrap gap-4">
+            <ul className="mt-6 space-y-3 text-sm text-white/90">
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2 w-2 rounded-full bg-accent-300" />
+                Plataforma digital para reservar espaços e acompanhar relatórios de performance.
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2 w-2 rounded-full bg-accent-300" />
+                Equipe de produção executiva, cenografia e suporte técnico para eventos corporativos.
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2 w-2 rounded-full bg-accent-300" />
+                Conexão com fornecedores homologados de catering, tecnologia e experiências imersivas.
+              </li>
+            </ul>
             <Link
               to="/contato"
-              className="inline-flex items-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-[#0b4f6c] shadow-sm transition hover:bg-accent-100"
+              className="inline-flex items-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-primary-700 shadow-lg transition-colors hover:bg-accent-200"
             >
-              Fale com o time comercial
+              Solicitar proposta
             </Link>
-            <Link
-              to="/salas"
-              className="inline-flex items-center rounded-full border border-white/60 px-6 py-3 text-sm font-semibold text-white transition hover:border-white hover:bg-white/10"
-            >
-              Ver todas as salas
-            </Link>
+          </div>
+          <div className="relative space-y-6">
+            <div className="space-y-4 rounded-2xl bg-white/90 p-6 text-sm text-primary-700 shadow-lg backdrop-blur">
+              <h3 className="text-lg font-semibold text-primary-800">Infraestrutura completa</h3>
+              <p className="text-[#4f5d55]">
+                Estacionamento para convidados, salas de apoio, camarins, wi-fi dedicado, sonorização e equipe de recepção bilíngue para seus eventos.
+              </p>
+            </div>
+            <div className="space-y-4 rounded-2xl bg-white/90 p-6 text-sm text-primary-700 shadow-lg backdrop-blur">
+              <h3 className="text-lg font-semibold text-primary-800">Hospitalidade e serviços</h3>
+              <p className="text-[#4f5d55]">
+                Concierge corporativo, curadoria gastronômica e programação cultural que potencializa experiências inesquecíveis.
+              </p>
+            </div>
+          </div>
+        </Container>
+        <div className="absolute -right-10 -top-10 h-40 w-40 rounded-full bg-primary-200/70 blur-3xl" aria-hidden />
+        <div className="absolute -bottom-10 -left-10 h-52 w-52 rounded-full bg-primary-300/60 blur-3xl" aria-hidden />
+      </section>
+
+      <section id="novidades">
+        <Container className="space-y-10">
+          <div className="max-w-3xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent-500">Novidades e eventos</p>
+            <h2 className="text-3xl font-bold text-primary-800 sm:text-4xl">Acompanhe o que acontece no Jaguar Center Plaza</h2>
+            <p className="text-base text-[#4f5d55]">
+              Programação cultural, ações sociais, eventos corporativos e novidades das empresas residentes.
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {newsPosts.map((post) => (
+              <article key={post.title} className="flex h-full flex-col overflow-hidden rounded-3xl bg-white shadow-lg">
+                <div className="relative h-48 w-full overflow-hidden">
+                  <img src={post.image} alt={post.title} className="h-full w-full object-cover" />
+                  <span className="absolute bottom-4 left-4 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-primary-700">
+                    {post.date}
+                  </span>
+                </div>
+                <div className="flex flex-1 flex-col gap-3 p-6">
+                  <h3 className="text-xl font-semibold text-primary-800">{post.title}</h3>
+                  <p className="flex-1 text-sm text-[#4f5d55]">{post.excerpt}</p>
+                  <Link
+                    to="/contato"
+                    className="inline-flex items-center text-sm font-semibold text-primary-600 transition-colors hover:text-accent-500"
+                  >
+                    Saiba mais
+                  </Link>
+                </div>
+              </article>
+            ))}
           </div>
         </Container>
       </section>


### PR DESCRIPTION
## Summary
- redesign the home page hero, feature, category, events and news sections to match the new marketing content and styling
- load categories through a new fetchCategories helper with graceful fallback data to populate the home page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1d66d06a08330b0789bbe285cbc2d