### PR TITLE
Add company directory experience with category and business pages

### DIFF
--- a/frontend/public/assets/categories-fallback.json
+++ b/frontend/public/assets/categories-fallback.json
@@ -1,45 +1,395 @@
 {
   "categories": [
     {
-      "id": "servicos-corporativos",
-      "name": "Serviços corporativos",
-      "description": "Contabilidade, advocacia, tecnologia e consultorias preparadas para apoiar o crescimento das empresas.",
+      "id": "administracao",
+      "slug": "administracao",
+      "name": "Administração",
+      "headline": "Consultorias, contabilidade e gestão estratégica para impulsionar empresas locais.",
+      "description": "Profissionais especializados em administração, finanças e gestão para apoiar o crescimento sustentável do seu negócio.",
+      "heroImage": "/Fachada.jpg",
+      "cardImage": "/Fachada.jpg",
       "companies": [
-        { "id": "contato-digital", "name": "Contato Digital" },
-        { "id": "atlas-contabilidade", "name": "Atlas Contabilidade" },
-        { "id": "plaza-tech", "name": "Plaza Tech Solutions" }
+        {
+          "id": "integra-consultoria",
+          "slug": "integra-consultoria",
+          "name": "Integra Consultoria Empresarial",
+          "tagline": "Planejamento financeiro, societário e de processos sob medida.",
+          "shortDescription": "Equipe multidisciplinar que estrutura diagnósticos, planos de ação e implementação de rotinas de gestão.",
+          "description": "A Integra Consultoria Empresarial atua há mais de 12 anos com assessoria estratégica, estruturação financeira, governança e implantação de indicadores para pequenas e médias empresas.",
+          "coverImage": "/Fachada4.jpg",
+          "logo": "/logo-jaguar-center-plaza-002b-768x535.png",
+          "phones": ["+55 (19) 3833-5601"],
+          "emails": ["contato@integraconsultoria.com.br"],
+          "website": "https://integraconsultoria.com.br",
+          "instagram": "https://instagram.com/integraconsultoria",
+          "address": "Sala 210 · Jaguar Center Plaza",
+          "mapsUrl": "https://maps.app.goo.gl/direcoes-jaguar-center-plaza",
+          "schedule": "Seg. a sex. · 8h às 18h",
+          "services": [
+            "Planejamento financeiro e orçamentário",
+            "Implantação de indicadores (KPIs)",
+            "Consultoria societária e sucessória"
+          ],
+          "gallery": [
+            { "url": "/Fachada.jpg", "alt": "Equipe da Integra Consultoria reunida em sala de reuniões" },
+            { "url": "/333674171_999380511025032_54232673152881839_n.jpg", "alt": "Workshop de planejamento com clientes" }
+          ],
+          "socialLinks": [
+            { "label": "Site", "url": "https://integraconsultoria.com.br", "type": "website" },
+            { "label": "Instagram", "url": "https://instagram.com/integraconsultoria", "type": "instagram" }
+          ]
+        },
+        {
+          "id": "atlas-contabilidade",
+          "slug": "atlas-contabilidade",
+          "name": "Atlas Contabilidade & BPO",
+          "tagline": "BPO financeiro, fiscal e folha integrado à tecnologia.",
+          "shortDescription": "Especialistas em terceirização de rotinas administrativas com dashboards em tempo real.",
+          "description": "A Atlas Contabilidade oferece soluções completas de contabilidade consultiva, gestão de folha, apuração fiscal e controladoria com acompanhamento digital.",
+          "coverImage": "/Fachada3.jpg",
+          "logo": "/logo-jaguar-center-plaza-002-1-768x535.png",
+          "phones": ["+55 (19) 3833-5602", "+55 (19) 99123-4455"],
+          "emails": ["relacionamento@atlasbpo.com.br"],
+          "website": "https://atlasbpo.com.br",
+          "instagram": "https://instagram.com/atlasbpo",
+          "address": "Sala 312 · Jaguar Center Plaza",
+          "mapsUrl": "https://maps.app.goo.gl/direcoes-jaguar-center-plaza",
+          "schedule": "Seg. a sex. · 8h às 18h",
+          "services": [
+            "BPO financeiro e administrativo",
+            "Gestão de folha e benefícios",
+            "Apuração fiscal e relatórios gerenciais"
+          ],
+          "gallery": [
+            { "url": "/333984251_205311685379957_6835703374332389472_n.jpg", "alt": "Equipe da Atlas reunida em frente ao Jaguar Center Plaza" },
+            { "url": "/img-jaguar-center-plaza-001-768x460.jpg", "alt": "Vista interna do Jaguar Center Plaza" }
+          ],
+          "socialLinks": [
+            { "label": "Site", "url": "https://atlasbpo.com.br", "type": "website" },
+            { "label": "Instagram", "url": "https://instagram.com/atlasbpo", "type": "instagram" }
+          ]
+        },
+        {
+          "id": "prime-gestao",
+          "slug": "prime-gestao",
+          "name": "Prime Gestão Condominial",
+          "tagline": "Administração condominial com suporte jurídico e financeiro.",
+          "shortDescription": "Atendimento personalizado para condomínios residenciais, comerciais e industriais.",
+          "description": "A Prime Gestão Condominial atende mais de 80 empreendimentos com soluções de governança, compliance, cobrança e prestação de contas digital.",
+          "coverImage": "/Fachada5.jpg",
+          "logo": "/logo-jaguar-center-plaza-002-1-768x535.png",
+          "phones": ["+55 (19) 3833-5603"],
+          "emails": ["relacionamento@primegestao.com.br"],
+          "website": "https://primegestao.com.br",
+          "instagram": "https://instagram.com/primegestaocondominial",
+          "address": "Sala 118 · Jaguar Center Plaza",
+          "mapsUrl": "https://maps.app.goo.gl/direcoes-jaguar-center-plaza",
+          "schedule": "Seg. a sex. · 8h às 17h",
+          "services": [
+            "Prestação de contas digital",
+            "Gestão de assembleias e comunicação",
+            "Consultoria jurídica condominial"
+          ],
+          "gallery": [
+            { "url": "/Fachada4.jpg", "alt": "Atendimento da Prime Gestão em sala corporativa" }
+          ],
+          "socialLinks": [
+            { "label": "Site", "url": "https://primegestao.com.br", "type": "website" },
+            { "label": "Instagram", "url": "https://instagram.com/primegestaocondominial", "type": "instagram" }
+          ]
+        }
       ]
     },
     {
-      "id": "saude-bem-estar",
-      "name": "Saúde & bem-estar",
-      "description": "Clínicas médicas, odontológicas, pilates, fisioterapia e terapias integrativas em ambientes acolhedores.",
+      "id": "advocacia",
+      "slug": "advocacia",
+      "name": "Advocacia",
+      "headline": "Escritórios especializados com atendimento consultivo e contencioso.",
+      "description": "Profissionais de direito empresarial, trabalhista, cível e tributário com foco em soluções ágeis e humanizadas.",
+      "heroImage": "/Fachada3.jpg",
+      "cardImage": "/Fachada3.jpg",
       "companies": [
-        { "id": "clinica-integrada", "name": "Clínica Integrada" },
-        { "id": "studio-pilates", "name": "Studio Pilates Plaza" },
-        { "id": "odontologia-plaza", "name": "Odontologia Plaza" }
+        {
+          "id": "andrade-azevedo",
+          "slug": "andrade-azevedo",
+          "name": "Andrade & Azevedo Sociedade de Advogados",
+          "tagline": "Estrutura completa para demandas empresariais e societárias.",
+          "shortDescription": "Atuação consultiva e contenciosa com equipe multidisciplinar em direito empresarial, societário e tributário.",
+          "description": "O escritório Andrade & Azevedo reúne especialistas em direito empresarial, societário e tributário. Atende empresas de médio e grande porte com foco na mitigação de riscos e na sustentabilidade jurídica dos negócios.",
+          "coverImage": "/Fachada.jpg",
+          "logo": "/logo-jaguar-center-plaza-002b-768x535.png",
+          "phones": ["+55 (19) 3833-5604"],
+          "emails": ["contato@andradeeazevedo.adv.br"],
+          "website": "https://andradeeazevedo.adv.br",
+          "instagram": "https://instagram.com/andradeeazevedo",
+          "address": "Sala 504 · Jaguar Center Plaza",
+          "mapsUrl": "https://maps.app.goo.gl/direcoes-jaguar-center-plaza",
+          "schedule": "Seg. a sex. · 8h30 às 18h",
+          "services": [
+            "Assessoria societária e governança",
+            "Planejamento tributário preventivo",
+            "Atuação contenciosa estratégica"
+          ],
+          "gallery": [
+            { "url": "/333984251_205311685379957_6835703374332389472_n.jpg", "alt": "Reunião da equipe Andrade & Azevedo" }
+          ],
+          "socialLinks": [
+            { "label": "Site", "url": "https://andradeeazevedo.adv.br", "type": "website" },
+            { "label": "Instagram", "url": "https://instagram.com/andradeeazevedo", "type": "instagram" }
+          ]
+        },
+        {
+          "id": "salvador-lima",
+          "slug": "salvador-lima",
+          "name": "Salvador Lima Advocacia Trabalhista",
+          "tagline": "Defesa e consultoria trabalhista para empresas e executivos.",
+          "shortDescription": "Atendimento especializado em negociações coletivas, auditoria trabalhista e contencioso estratégico.",
+          "description": "O escritório Salvador Lima atua há 20 anos em direito do trabalho, oferecendo consultoria preventiva, auditoria, due diligence e defesa em litígios estratégicos.",
+          "coverImage": "/Fachada5.jpg",
+          "logo": "/logo-jaguar-center-plaza-002-1-768x535.png",
+          "phones": ["+55 (19) 3833-5605"],
+          "emails": ["agenda@salvadorlima.adv.br"],
+          "website": "https://salvadorlima.adv.br",
+          "instagram": "https://instagram.com/salvadorlimaadv",
+          "address": "Sala 410 · Jaguar Center Plaza",
+          "mapsUrl": "https://maps.app.goo.gl/direcoes-jaguar-center-plaza",
+          "schedule": "Seg. a sex. · 9h às 18h",
+          "services": [
+            "Consultoria preventiva e compliance trabalhista",
+            "Negociação coletiva e acordos extrajudiciais",
+            "Defesa em ações trabalhistas complexas"
+          ],
+          "gallery": [
+            { "url": "/Fachada4.jpg", "alt": "Sala de atendimento do escritório Salvador Lima" }
+          ],
+          "socialLinks": [
+            { "label": "Site", "url": "https://salvadorlima.adv.br", "type": "website" },
+            { "label": "Instagram", "url": "https://instagram.com/salvadorlimaadv", "type": "instagram" }
+          ]
+        },
+        {
+          "id": "pires-rodrigues",
+          "slug": "pires-rodrigues",
+          "name": "Pires & Rodrigues Advocacia Cível",
+          "tagline": "Atuação personalizada em direito de família, sucessões e imobiliário.",
+          "shortDescription": "Equipe voltada para demandas cíveis com mediação humanizada e foco em resultados.",
+          "description": "A Pires & Rodrigues é referência regional em mediação e resolução de conflitos cíveis, imobiliários e de família, com suporte jurídico completo.",
+          "coverImage": "/Fachada3.jpg",
+          "logo": "/logo-jaguar-center-plaza-002b-768x535.png",
+          "phones": ["+55 (19) 3833-5606"],
+          "emails": ["contato@piresrodrigues.adv.br"],
+          "instagram": "https://instagram.com/piresrodriguesadv",
+          "address": "Sala 220 · Jaguar Center Plaza",
+          "mapsUrl": "https://maps.app.goo.gl/direcoes-jaguar-center-plaza",
+          "schedule": "Seg. a sex. · 8h às 17h",
+          "services": [
+            "Mediação e conciliação familiar",
+            "Regularização imobiliária",
+            "Inventários e planejamento sucessório"
+          ],
+          "gallery": [
+            { "url": "/Fachada.jpg", "alt": "Equipe da Pires & Rodrigues atendendo clientes" }
+          ],
+          "socialLinks": [
+            { "label": "Instagram", "url": "https://instagram.com/piresrodriguesadv", "type": "instagram" }
+          ]
+        }
       ]
     },
     {
-      "id": "gastronomia-conveniencia",
-      "name": "Gastronomia & conveniência",
-      "description": "Restaurantes, cafeterias, mercado e opções rápidas para quem precisa praticidade no dia a dia.",
+      "id": "contabilidade",
+      "slug": "contabilidade",
+      "name": "Contabilidade",
+      "headline": "Contadores parceiros para manter a saúde financeira da sua empresa.",
+      "description": "Escritórios contábeis com soluções digitais, consultoria fiscal e suporte ao empreendedor.",
+      "heroImage": "/Fachada4.jpg",
+      "cardImage": "/Fachada4.jpg",
       "companies": [
-        { "id": "cafe-jaguar", "name": "Café Jaguar" },
-        { "id": "emporio-centro", "name": "Empório do Centro" },
-        { "id": "praca-sabores", "name": "Praça Sabores" }
+        {
+          "id": "plaza-contabil",
+          "slug": "plaza-contabil",
+          "name": "Plaza Contábil Inteligente",
+          "tagline": "Contabilidade consultiva e digital com dashboard em tempo real.",
+          "shortDescription": "Especialistas em negócios do varejo, saúde e serviços, com acompanhamento próximo ao empreendedor.",
+          "description": "A Plaza Contábil Inteligente oferece assessoria completa em abertura de empresas, planejamento tributário, folha de pagamento e contabilidade consultiva.",
+          "coverImage": "/Fachada5.jpg",
+          "logo": "/logo-jaguar-center-plaza-002-1-768x535.png",
+          "phones": ["+55 (19) 3833-5607"],
+          "emails": ["contato@plazacontabil.com.br"],
+          "website": "https://plazacontabil.com.br",
+          "instagram": "https://instagram.com/plazacontabil",
+          "address": "Sala 315 · Jaguar Center Plaza",
+          "mapsUrl": "https://maps.app.goo.gl/direcoes-jaguar-center-plaza",
+          "schedule": "Seg. a sex. · 8h às 18h",
+          "services": [
+            "Planejamento tributário",
+            "Gestão de folha e benefícios",
+            "Relatórios gerenciais em tempo real"
+          ],
+          "gallery": [
+            { "url": "/333674171_999380511025032_54232673152881839_n.jpg", "alt": "Equipe da Plaza Contábil em reunião" }
+          ],
+          "socialLinks": [
+            { "label": "Site", "url": "https://plazacontabil.com.br", "type": "website" },
+            { "label": "Instagram", "url": "https://instagram.com/plazacontabil", "type": "instagram" }
+          ]
+        },
+        {
+          "id": "domus-fiscal",
+          "slug": "domus-fiscal",
+          "name": "Domus Fiscal & Auditoria",
+          "tagline": "Especialistas em auditoria tributária e revisão de benefícios fiscais.",
+          "shortDescription": "Mais de 15 anos de atuação em consultoria e auditoria fiscal no interior paulista.",
+          "description": "A Domus Fiscal é referência regional em auditoria e recuperação de créditos tributários, com equipe composta por contadores e advogados tributaristas.",
+          "coverImage": "/Fachada3.jpg",
+          "logo": "/logo-jaguar-center-plaza-002b-768x535.png",
+          "phones": ["+55 (19) 3833-5608"],
+          "emails": ["relacionamento@domusfiscal.com.br"],
+          "instagram": "https://instagram.com/domusfiscal",
+          "address": "Sala 221 · Jaguar Center Plaza",
+          "mapsUrl": "https://maps.app.goo.gl/direcoes-jaguar-center-plaza",
+          "schedule": "Seg. a sex. · 8h30 às 17h30",
+          "services": [
+            "Auditoria tributária completa",
+            "Recuperação de créditos",
+            "Treinamentos in company"
+          ],
+          "gallery": [
+            { "url": "/Fachada4.jpg", "alt": "Reunião de consultores Domus Fiscal" }
+          ],
+          "socialLinks": [
+            { "label": "Instagram", "url": "https://instagram.com/domusfiscal", "type": "instagram" }
+          ]
+        },
+        {
+          "id": "epsilon-contabilidade",
+          "slug": "epsilon-contabilidade",
+          "name": "Epsilon Contabilidade Consultiva",
+          "tagline": "Tecnologia e proximidade para o dia a dia do empreendedor.",
+          "shortDescription": "Consultoria contábil com foco em startups, profissionais liberais e franquias.",
+          "description": "A Epsilon Contabilidade alia tecnologia, atendimento consultivo e planejamento tributário para negócios em expansão.",
+          "coverImage": "/Fachada.jpg",
+          "logo": "/logo-jaguar-center-plaza-002-1-768x535.png",
+          "phones": ["+55 (19) 3833-5609"],
+          "emails": ["contato@epsiloncontabil.com.br"],
+          "website": "https://epsiloncontabil.com.br",
+          "instagram": "https://instagram.com/epsiloncontabil",
+          "address": "Sala 214 · Jaguar Center Plaza",
+          "mapsUrl": "https://maps.app.goo.gl/direcoes-jaguar-center-plaza",
+          "schedule": "Seg. a sex. · 8h às 18h",
+          "services": [
+            "Abertura e regularização de empresas",
+            "Consultoria contábil e financeira",
+            "BPO fiscal e trabalhista"
+          ],
+          "gallery": [
+            { "url": "/img-jaguar-center-plaza-001-768x460.jpg", "alt": "Espaço compartilhado da Epsilon Contabilidade" }
+          ],
+          "socialLinks": [
+            { "label": "Site", "url": "https://epsiloncontabil.com.br", "type": "website" },
+            { "label": "Instagram", "url": "https://instagram.com/epsiloncontabil", "type": "instagram" }
+          ]
+        }
       ]
     },
     {
-      "id": "beleza-estetica",
-      "name": "Beleza & estética",
-      "description": "Centros de estética, salões e barbearias com serviços premium e profissionais especializados.",
+      "id": "beleza",
+      "slug": "beleza",
+      "name": "Beleza & bem-estar",
+      "headline": "Estúdios e centros de estética que valorizam autocuidado, saúde e autoestima.",
+      "description": "Experiências completas de beleza, terapias corporais, pilates e bem-estar para todas as idades.",
+      "heroImage": "/Fachada5.jpg",
+      "cardImage": "/Fachada5.jpg",
       "companies": [
-        { "id": "studio-beleza", "name": "Studio Beleza" },
-        { "id": "spa-jaguar", "name": "Spa Jaguar" },
-        { "id": "barbearia-plaza", "name": "Barbearia Plaza" }
+        {
+          "id": "studio-alessandra-moraes",
+          "slug": "studio-alessandra-moraes",
+          "name": "Studio Alessandra Moraes",
+          "tagline": "Pilates, treinamento funcional e terapias integrativas.",
+          "shortDescription": "Espaço completo com aulas personalizadas, equipamentos modernos e acompanhamento multidisciplinar.",
+          "description": "O Studio Alessandra Moraes é um ambiente dedicado ao movimento consciente, pilates, treinamento funcional, barras de access, ventosaterapia e bem-estar integral.",
+          "coverImage": "/Fachada4.jpg",
+          "logo": "/1.png",
+          "phones": ["+55 (19) 99697-6642"],
+          "emails": ["ale.pca@hotmail.com"],
+          "instagram": "https://instagram.com/studioalessandramoraes",
+          "address": "Sala 117 · Jaguar Center Plaza",
+          "mapsUrl": "https://maps.app.goo.gl/direcoes-jaguar-center-plaza",
+          "schedule": "Seg. a sex. · 7h às 21h · Sáb. · 8h às 13h",
+          "services": [
+            "Pilates clássico e contemporâneo",
+            "Treinamento funcional",
+            "Terapias integrativas"
+          ],
+          "gallery": [
+            { "url": "/jaguar center plaza - Jaguariuna.jpg", "alt": "Sala de pilates do Studio Alessandra Moraes" },
+            { "url": "/jaguar center plaza - Jaguariuna_edited.jpg", "alt": "Alunos praticando treinamento funcional" },
+            { "url": "/Fachada5.jpg", "alt": "Entrada do Studio Alessandra Moraes" }
+          ],
+          "socialLinks": [
+            { "label": "Instagram", "url": "https://instagram.com/studioalessandramoraes", "type": "instagram" },
+            { "label": "WhatsApp", "url": "https://wa.me/5519996976642", "type": "whatsapp" }
+          ]
+        },
+        {
+          "id": "barber-dom-fernandes",
+          "slug": "barber-dom-fernandes",
+          "name": "Barber Shop Dom Fernandes",
+          "tagline": "Barbearia premium com lounge, bar e experiências personalizadas.",
+          "shortDescription": "Cortes clássicos e modernos, terapia capilar, bar com drinks autorais e eventos temáticos.",
+          "description": "A Dom Fernandes oferece experiência completa de grooming masculino, com barbearia, spa capilar, bar, mesas de sinuca e curadoria musical semanal.",
+          "coverImage": "/Fachada3.jpg",
+          "logo": "/logo-jaguar-center-plaza-002b-768x535.png",
+          "phones": ["+55 (19) 99874-1020"],
+          "instagram": "https://instagram.com/domfernandesbarber",
+          "address": "Sala 028 · Piso térreo · Jaguar Center Plaza",
+          "mapsUrl": "https://maps.app.goo.gl/direcoes-jaguar-center-plaza",
+          "schedule": "Ter. a sex. · 10h às 21h · Sáb. · 9h às 19h",
+          "services": [
+            "Cortes, barba e design de sobrancelha",
+            "Terapia capilar e spa para barba",
+            "Eventos temáticos com DJ e mixologia"
+          ],
+          "gallery": [
+            { "url": "/333984251_205311685379957_6835703374332389472_n.jpg", "alt": "Barbearia Dom Fernandes com clientes" },
+            { "url": "/333674171_999380511025032_54232673152881839_n.jpg", "alt": "Bar da barbearia Dom Fernandes" }
+          ],
+          "socialLinks": [
+            { "label": "Instagram", "url": "https://instagram.com/domfernandesbarber", "type": "instagram" },
+            { "label": "WhatsApp", "url": "https://wa.me/5519998741020", "type": "whatsapp" }
+          ]
+        },
+        {
+          "id": "galeria-retro",
+          "slug": "galeria-retro",
+          "name": "Galeria Retrô Estética",
+          "tagline": "Centro de estética avançada com protocolos exclusivos.",
+          "shortDescription": "Tratamentos faciais, corporais e depilação a laser com equipamentos de alta performance.",
+          "description": "A Galeria Retrô combina estética avançada, consultoria de imagem e produtos dermocosméticos exclusivos em um ambiente acolhedor.",
+          "coverImage": "/Fachada.jpg",
+          "logo": "/logo-jaguar-center-plaza-002-1-768x535.png",
+          "phones": ["+55 (19) 99852-4411"],
+          "emails": ["contato@galeriaretro.com.br"],
+          "instagram": "https://instagram.com/galeriaretroestetica",
+          "address": "Sala 036 · Jaguar Center Plaza",
+          "mapsUrl": "https://maps.app.goo.gl/direcoes-jaguar-center-plaza",
+          "schedule": "Seg. a sáb. · 9h às 20h",
+          "services": [
+            "Limpeza de pele e revitalização facial",
+            "Tratamentos corporais e drenagem linfática",
+            "Depilação a laser e design de sobrancelhas"
+          ],
+          "gallery": [
+            { "url": "/Fachada5.jpg", "alt": "Sala de atendimento da Galeria Retrô" },
+            { "url": "/jaguar center plaza - Jaguariuna.jpg", "alt": "Detalhes do ambiente da Galeria Retrô" }
+          ],
+          "socialLinks": [
+            { "label": "Instagram", "url": "https://instagram.com/galeriaretroestetica", "type": "instagram" },
+            { "label": "WhatsApp", "url": "https://wa.me/5519998524411", "type": "whatsapp" }
+          ]
+        }
       ]
     }
   ],
-  "generatedAt": "2024-01-01T00:00:00.000Z"
+  "generatedAt": "2024-06-01T00:00:00.000Z"
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,9 @@ import Layout from './components/layout/Layout';
 import AboutPage from './pages/About';
 import ContactPage from './pages/Contact';
 import HomePage from './pages/Home';
+import CompaniesPage from './pages/Companies';
+import CompanyCategoryPage from './pages/CompanyCategory';
+import CompanyDetailPage from './pages/CompanyDetail';
 import NotFoundPage from './pages/NotFound';
 import RoomsPage from './pages/Rooms';
 
@@ -11,6 +14,9 @@ function App() {
     <Layout>
       <Routes>
         <Route path="/" element={<HomePage />} />
+        <Route path="/empresas" element={<CompaniesPage />} />
+        <Route path="/empresas/:categorySlug" element={<CompanyCategoryPage />} />
+        <Route path="/empresas/:categorySlug/:companySlug" element={<CompanyDetailPage />} />
         <Route path="/sobre-nos" element={<AboutPage />} />
         <Route path="/salas" element={<RoomsPage />} />
         <Route path="/contato" element={<ContactPage />} />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -6,6 +6,7 @@ import { fetchAreas } from '../../lib/api';
 
 const navItems = [
   { label: 'Home', to: '/', type: 'route' as const },
+  { label: 'Empresas', to: '/empresas', type: 'route' as const },
   { label: 'Sobre nós', to: '/sobre-nos', type: 'route' as const },
   { label: 'Salas', to: '/salas', type: 'route' as const },
   { label: 'Contato', to: '/contato', type: 'route' as const }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -32,15 +32,50 @@ export interface AreasResponse {
   generatedAt?: string;
 }
 
+export interface CompanyMedia {
+  url: string;
+  alt?: string;
+}
+
+export interface CompanySocialLink {
+  label: string;
+  url: string;
+  type?: 'website' | 'instagram' | 'facebook' | 'whatsapp' | 'linkedin';
+}
+
 export interface CompanySummary {
   id: string;
+  slug?: string;
   name: string;
+  tagline?: string;
+  shortDescription?: string;
+  description?: string;
+  coverImage?: string;
+  logo?: string;
+  highlight?: boolean;
+  phones?: string[];
+  emails?: string[];
+  whatsapp?: string;
+  website?: string;
+  instagram?: string;
+  facebook?: string;
+  linkedin?: string;
+  address?: string;
+  mapsUrl?: string;
+  schedule?: string;
+  services?: string[];
+  gallery?: CompanyMedia[];
+  socialLinks?: CompanySocialLink[];
 }
 
 export interface CompanyCategory {
   id: string;
+  slug?: string;
   name: string;
   description?: string;
+  headline?: string;
+  heroImage?: string;
+  cardImage?: string;
   companies: CompanySummary[];
 }
 

--- a/frontend/src/pages/Companies.tsx
+++ b/frontend/src/pages/Companies.tsx
@@ -1,0 +1,115 @@
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import Container from '../components/layout/Container';
+import { fetchCategories, type CompanyCategory } from '../lib/api';
+import { useSEO } from '../hooks/useSEO';
+
+function formatCompaniesLabel(count: number | undefined) {
+  if (!count || count <= 0) {
+    return 'Conheça as empresas';
+  }
+
+  if (count === 1) {
+    return '1 empresa';
+  }
+
+  return `${count} empresas`;
+}
+
+export default function CompaniesPage() {
+  const { data, isLoading, isError } = useQuery({ queryKey: ['categories'], queryFn: fetchCategories });
+  const categories = data?.categories ?? [];
+
+  useSEO({
+    title: 'Empresas por setor · Jaguar Center Plaza',
+    description:
+      'Explore as empresas residentes do Jaguar Center Plaza organizadas por segmentos como administração, advocacia, contabilidade e beleza.',
+    canonical: 'https://www.jaguarcenterplaza.com.br/empresas'
+  });
+
+  return (
+    <div className="space-y-20 pb-20">
+      <section className="relative overflow-hidden bg-gradient-to-br from-primary-800 via-primary-700 to-primary-500 py-24 text-white">
+        <div className="absolute inset-0 bg-[url('/Fachada3.jpg')] bg-cover bg-center opacity-20" aria-hidden />
+        <div className="absolute inset-0 bg-primary-900/60" aria-hidden />
+        <Container className="relative z-10 space-y-6">
+          <p className="inline-flex items-center rounded-full bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em]">
+            Jaguar Center Plaza
+          </p>
+          <h1 className="text-4xl font-bold sm:text-5xl">Empresas por setor</h1>
+          <p className="max-w-3xl text-base text-white/80 sm:text-lg">
+            Conheça os segmentos presentes no Jaguar Center Plaza e encontre empresas especializadas em administração, advocacia, contabilidade, beleza e bem-estar.
+          </p>
+          <div className="flex flex-wrap gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-accent-200">
+            <span>Consultorias</span>
+            <span>Saúde corporativa</span>
+            <span>Beleza & bem-estar</span>
+            <span>Serviços essenciais</span>
+          </div>
+        </Container>
+      </section>
+
+      <section>
+        <Container className="space-y-10">
+          <div className="max-w-2xl space-y-4">
+            <h2 className="text-3xl font-bold text-primary-800 sm:text-4xl">Categorias de empresas</h2>
+            <p className="text-base text-[#4f5d55]">
+              Explore as categorias para descobrir serviços, contatos e diferenciais de cada empresa presente no complexo.
+            </p>
+          </div>
+
+          {isLoading && (
+            <div className="rounded-3xl bg-white p-6 shadow-lg">
+              <p className="text-sm text-[#4f5d55]">Carregando categorias...</p>
+            </div>
+          )}
+
+          {isError && !isLoading && (
+            <div className="rounded-3xl bg-red-50 p-6 shadow-lg">
+              <p className="text-sm text-red-600">Não foi possível carregar as categorias agora. Tente novamente em instantes.</p>
+            </div>
+          )}
+
+          {!isLoading && !isError && categories.length === 0 && (
+            <div className="rounded-3xl bg-white p-6 shadow-lg">
+              <p className="text-sm text-[#4f5d55]">Nenhuma categoria cadastrada no momento.</p>
+            </div>
+          )}
+
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {categories.map((category: CompanyCategory) => {
+              const slug = category.slug || category.id;
+              const companiesCount = category.companies?.length ?? 0;
+              const image = category.cardImage || category.heroImage || '/Fachada5.jpg';
+
+              return (
+                <article key={slug} className="group flex h-full flex-col overflow-hidden rounded-3xl bg-white shadow-lg transition hover:-translate-y-1 hover:shadow-xl">
+                  <div className="relative h-56 w-full overflow-hidden">
+                    <img src={image} alt={category.name} className="h-full w-full object-cover transition duration-500 group-hover:scale-105" />
+                    <span className="absolute left-4 top-4 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-primary-700">
+                      {formatCompaniesLabel(companiesCount)}
+                    </span>
+                  </div>
+                  <div className="flex flex-1 flex-col gap-3 p-6">
+                    <h3 className="text-xl font-semibold text-primary-800">{category.name}</h3>
+                    <p className="flex-1 text-sm text-[#4f5d55]">{category.description}</p>
+                    <Link
+                      to={`/empresas/${slug}`}
+                      className="inline-flex items-center gap-2 text-sm font-semibold text-primary-600 transition-colors hover:text-accent-500"
+                    >
+                      Ver mais
+                      <svg aria-hidden className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+                        <path d="M5 12h14" strokeLinecap="round" strokeLinejoin="round" />
+                        <path d="m13 6 6 6-6 6" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </Link>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </Container>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/CompanyCategory.tsx
+++ b/frontend/src/pages/CompanyCategory.tsx
@@ -1,0 +1,147 @@
+import { Link, useParams } from 'react-router-dom';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Container from '../components/layout/Container';
+import { fetchCategories, type CompanyCategory as CompanyCategoryType, type CompanySummary } from '../lib/api';
+import { useSEO } from '../hooks/useSEO';
+
+function formatCompaniesLabel(count: number | undefined) {
+  if (!count || count <= 0) {
+    return 'Empresas disponíveis';
+  }
+
+  if (count === 1) {
+    return '1 empresa';
+  }
+
+  return `${count} empresas`;
+}
+
+export default function CompanyCategoryPage() {
+  const { categorySlug = '' } = useParams();
+  const { data, isLoading, isError } = useQuery({ queryKey: ['categories'], queryFn: fetchCategories });
+  const categories = data?.categories ?? [];
+
+  const category = useMemo<CompanyCategoryType | undefined>(
+    () => categories.find((item) => (item.slug || item.id) === categorySlug),
+    [categories, categorySlug]
+  );
+
+  useSEO({
+    title: category
+      ? `${category.name} · Empresas no Jaguar Center Plaza`
+      : 'Categorias de empresas · Jaguar Center Plaza',
+    description:
+      category?.description ||
+      'Descubra empresas residentes no Jaguar Center Plaza organizadas por categorias de serviços corporativos e bem-estar.'
+  });
+
+  const heroImage = category?.heroImage || '/Fachada4.jpg';
+  const companies = category?.companies ?? [];
+
+  return (
+    <div className="space-y-16 pb-20">
+      <section className="relative overflow-hidden bg-primary-900 text-white">
+        <div className="absolute inset-0">
+          <img src={heroImage} alt="Setor" className="h-full w-full object-cover opacity-40" />
+          <div className="absolute inset-0 bg-gradient-to-r from-primary-900/90 via-primary-800/90 to-primary-700/80" aria-hidden />
+        </div>
+        <Container className="relative z-10 space-y-6 py-24">
+          <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-accent-200">
+            <Link to="/" className="transition hover:text-white">
+              Home
+            </Link>
+            <span>/</span>
+            <Link to="/empresas" className="transition hover:text-white">
+              Empresas
+            </Link>
+            {category && (
+              <>
+                <span>/</span>
+                <span className="text-white/80">{category.name}</span>
+              </>
+            )}
+          </nav>
+          <div className="space-y-4">
+            <p className="inline-flex items-center rounded-full bg-white/15 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em]">
+              {category ? category.headline || 'Empresas do setor' : 'Empresas por setor'}
+            </p>
+            <h1 className="text-4xl font-bold sm:text-5xl">{category ? category.name : 'Categorias de empresas'}</h1>
+            {category?.description && <p className="max-w-3xl text-base text-white/80 sm:text-lg">{category.description}</p>}
+            <div className="text-sm font-semibold text-accent-100">{formatCompaniesLabel(companies.length)}</div>
+          </div>
+        </Container>
+      </section>
+
+      <section>
+        <Container className="space-y-8">
+          {isLoading && (
+            <div className="rounded-3xl bg-white p-6 shadow-lg">
+              <p className="text-sm text-[#4f5d55]">Carregando empresas...</p>
+            </div>
+          )}
+
+          {isError && !isLoading && (
+            <div className="rounded-3xl bg-red-50 p-6 shadow-lg">
+              <p className="text-sm text-red-600">Não foi possível carregar as empresas agora. Tente novamente em instantes.</p>
+            </div>
+          )}
+
+          {!isLoading && !isError && !category && (
+            <div className="rounded-3xl bg-white p-8 text-center shadow-lg">
+              <h2 className="text-2xl font-semibold text-primary-800">Categoria não encontrada</h2>
+              <p className="mt-2 text-sm text-[#4f5d55]">A categoria que você procurou pode ter sido removida ou está indisponível no momento.</p>
+              <div className="mt-6">
+                <Link to="/empresas" className="inline-flex items-center rounded-full bg-primary-700 px-5 py-2 text-sm font-semibold text-white transition hover:bg-primary-600">
+                  Ver todas as categorias
+                </Link>
+              </div>
+            </div>
+          )}
+
+          {category && companies.length === 0 && !isLoading && !isError && (
+            <div className="rounded-3xl bg-white p-6 shadow-lg">
+              <p className="text-sm text-[#4f5d55]">Ainda não há empresas cadastradas nesta categoria.</p>
+            </div>
+          )}
+
+          {category && companies.length > 0 && (
+            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+              {companies.map((company: CompanySummary) => {
+                const companySlug = company.slug || company.id;
+                const image = company.coverImage || category.heroImage || '/Fachada5.jpg';
+
+                return (
+                  <article key={companySlug} className="flex h-full flex-col overflow-hidden rounded-3xl bg-white shadow-lg">
+                    <div className="relative h-48 w-full overflow-hidden">
+                      <img src={image} alt={company.name} className="h-full w-full object-cover" />
+                      {company.tagline && (
+                        <span className="absolute left-4 top-4 rounded-full bg-white/90 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary-700">
+                          {company.tagline}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex flex-1 flex-col gap-3 p-6">
+                      <div className="space-y-1">
+                        <h2 className="text-xl font-semibold text-primary-800">{company.name}</h2>
+                        {company.shortDescription && <p className="text-sm text-[#4f5d55]">{company.shortDescription}</p>}
+                      </div>
+                      <div className="mt-auto">
+                        <Link
+                          to={`/empresas/${category.slug || category.id}/${companySlug}`}
+                          className="inline-flex items-center rounded-full bg-primary-700 px-5 py-2 text-sm font-semibold text-white transition hover:bg-primary-600"
+                        >
+                          Saiba mais
+                        </Link>
+                      </div>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </Container>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/CompanyDetail.tsx
+++ b/frontend/src/pages/CompanyDetail.tsx
@@ -1,0 +1,273 @@
+import { Link, useParams } from 'react-router-dom';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Container from '../components/layout/Container';
+import {
+  fetchCategories,
+  type CompanyCategory,
+  type CompanySummary,
+  type CompanySocialLink,
+  type CompanyMedia
+} from '../lib/api';
+import { useSEO } from '../hooks/useSEO';
+
+function formatPhone(value: string) {
+  return value.replace(/[^+\d]/g, '');
+}
+
+function normalizeLink(link?: string) {
+  if (!link) return undefined;
+  if (link.startsWith('http')) return link;
+  return `https://${link.replace(/^\/+/, '')}`;
+}
+
+export default function CompanyDetailPage() {
+  const { categorySlug = '', companySlug = '' } = useParams();
+  const { data, isLoading, isError } = useQuery({ queryKey: ['categories'], queryFn: fetchCategories });
+  const categories = data?.categories ?? [];
+
+  const { category, company } = useMemo(() => {
+    const foundCategory = categories.find((item: CompanyCategory) => (item.slug || item.id) === categorySlug);
+    const foundCompany = foundCategory?.companies?.find((item: CompanySummary) => (item.slug || item.id) === companySlug);
+
+    return { category: foundCategory, company: foundCompany };
+  }, [categories, categorySlug, companySlug]);
+
+  useSEO({
+    title: company
+      ? `${company.name} · ${category?.name ?? 'Empresas'} · Jaguar Center Plaza`
+      : 'Empresa não encontrada · Jaguar Center Plaza',
+    description:
+      company?.shortDescription ||
+      company?.description ||
+      'Conheça as empresas que fazem parte do Jaguar Center Plaza e seus diferenciais de atendimento.',
+    canonical: company ? `https://www.jaguarcenterplaza.com.br/empresas/${categorySlug}/${companySlug}` : undefined
+  });
+
+  const gallery = company?.gallery ?? [];
+  const socialLinks: CompanySocialLink[] = company?.socialLinks ?? [];
+  const heroImage = company?.coverImage || category?.heroImage || '/Fachada5.jpg';
+
+  return (
+    <div className="space-y-16 pb-20">
+      <section className="relative overflow-hidden bg-primary-900 text-white">
+        <div className="absolute inset-0">
+          <img src={heroImage} alt={company?.name || 'Empresa'} className="h-full w-full object-cover opacity-40" />
+          <div className="absolute inset-0 bg-gradient-to-r from-primary-900/95 via-primary-800/90 to-primary-700/80" aria-hidden />
+        </div>
+        <Container className="relative z-10 space-y-6 py-24">
+          <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-accent-200">
+            <Link to="/" className="transition hover:text-white">
+              Home
+            </Link>
+            <span>/</span>
+            <Link to="/empresas" className="transition hover:text-white">
+              Empresas
+            </Link>
+            {category && (
+              <>
+                <span>/</span>
+                <Link to={`/empresas/${category.slug || category.id}`} className="transition hover:text-white">
+                  {category.name}
+                </Link>
+              </>
+            )}
+            {company && (
+              <>
+                <span>/</span>
+                <span className="text-white/80">{company.name}</span>
+              </>
+            )}
+          </nav>
+          <div className="space-y-4">
+            {company?.logo && (
+              <img src={company.logo} alt={company.name} className="h-16 w-auto" />
+            )}
+            <h1 className="text-4xl font-bold sm:text-5xl">{company ? company.name : 'Empresa não encontrada'}</h1>
+            {company?.tagline && <p className="text-base font-semibold uppercase tracking-[0.25em] text-accent-200">{company.tagline}</p>}
+            {company?.shortDescription && <p className="max-w-3xl text-base text-white/85 sm:text-lg">{company.shortDescription}</p>}
+          </div>
+        </Container>
+      </section>
+
+      <section>
+        <Container className="grid gap-12 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+          <div className="space-y-8">
+            {company?.description && (
+              <div className="rounded-3xl bg-white p-8 shadow-lg">
+                <h2 className="text-2xl font-semibold text-primary-800">Sobre a empresa</h2>
+                <p className="mt-3 text-base leading-relaxed text-[#4f5d55]">{company.description}</p>
+                {company.services && company.services.length > 0 && (
+                  <div className="mt-6 space-y-3">
+                    <h3 className="text-lg font-semibold text-primary-800">Principais serviços</h3>
+                    <ul className="space-y-2 text-sm text-[#4f5d55]">
+                      {company.services.map((service) => (
+                        <li key={service} className="flex items-start gap-2">
+                          <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary-500" />
+                          <span>{service}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {gallery.length > 0 && (
+              <div className="space-y-4">
+                <h2 className="text-2xl font-semibold text-primary-800">Galeria</h2>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {gallery.map((item: CompanyMedia) => (
+                    <div key={item.url} className="overflow-hidden rounded-2xl shadow-lg">
+                      <img src={item.url} alt={item.alt || company?.name || 'Empresa'} className="h-60 w-full object-cover" />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <aside className="space-y-6">
+            <div className="rounded-3xl bg-white p-8 shadow-lg">
+              <h2 className="text-xl font-semibold text-primary-800">Informações de contato</h2>
+              <div className="mt-4 space-y-4 text-sm text-[#4f5d55]">
+                {company?.phones && company.phones.length > 0 && (
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-primary-500">Telefone</p>
+                    <ul className="mt-2 space-y-1">
+                      {company.phones.map((phone) => (
+                        <li key={phone}>
+                          <a href={`tel:${formatPhone(phone)}`} className="font-medium text-primary-700 hover:text-accent-500">
+                            {phone}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {company?.emails && company.emails.length > 0 && (
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-primary-500">E-mail</p>
+                    <ul className="mt-2 space-y-1">
+                      {company.emails.map((email) => (
+                        <li key={email}>
+                          <a href={`mailto:${email}`} className="font-medium text-primary-700 hover:text-accent-500">
+                            {email}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {company?.website && (
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-primary-500">Site</p>
+                    <a
+                      href={normalizeLink(company.website)}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="mt-2 inline-flex items-center gap-2 font-medium text-primary-700 hover:text-accent-500"
+                    >
+                      {company.website.replace(/^https?:\/\//, '')}
+                      <svg aria-hidden className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+                        <path d="M7 17 17 7" strokeLinecap="round" strokeLinejoin="round" />
+                        <path d="M8 7h9v9" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </a>
+                  </div>
+                )}
+                {company?.instagram && (
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-primary-500">Instagram</p>
+                    <a
+                      href={normalizeLink(company.instagram)}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="mt-2 inline-flex items-center gap-2 font-medium text-primary-700 hover:text-accent-500"
+                    >
+                      {company.instagram.replace(/^https?:\/\//, '')}
+                    </a>
+                  </div>
+                )}
+                {company?.address && (
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-primary-500">Endereço</p>
+                    <p className="mt-2 font-medium text-primary-700">{company.address}</p>
+                    {company.mapsUrl && (
+                      <a
+                        href={normalizeLink(company.mapsUrl)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="mt-1 inline-flex items-center gap-2 text-sm font-semibold text-primary-600 hover:text-accent-500"
+                      >
+                        Ver no mapa
+                        <svg aria-hidden className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+                          <path d="M12 21s-6-5.686-6-10a6 6 0 1 1 12 0c0 4.314-6 10-6 10z" />
+                          <circle cx="12" cy="11" r="2.5" />
+                        </svg>
+                      </a>
+                    )}
+                  </div>
+                )}
+                {company?.schedule && (
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-primary-500">Horário de atendimento</p>
+                    <p className="mt-2 font-medium text-primary-700">{company.schedule}</p>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {socialLinks.length > 0 && (
+              <div className="rounded-3xl bg-white p-8 shadow-lg">
+                <h2 className="text-xl font-semibold text-primary-800">Redes e canais</h2>
+                <ul className="mt-4 space-y-3 text-sm text-[#4f5d55]">
+                  {socialLinks.map((social) => (
+                    <li key={social.url}>
+                      <a
+                        href={normalizeLink(social.url)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-2 font-semibold text-primary-700 hover:text-accent-500"
+                      >
+                        {social.label}
+                        <svg aria-hidden className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+                          <path d="M7 17 17 7" strokeLinecap="round" strokeLinejoin="round" />
+                          <path d="M8 7h9v9" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </aside>
+        </Container>
+      </section>
+
+      {!isLoading && !isError && !company && (
+        <Container>
+          <div className="rounded-3xl bg-white p-8 text-center shadow-lg">
+            <h2 className="text-2xl font-semibold text-primary-800">Empresa não encontrada</h2>
+            <p className="mt-2 text-sm text-[#4f5d55]">
+              A empresa que você buscou pode ter sido removida ou está temporariamente indisponível.
+            </p>
+            <div className="mt-6 flex flex-wrap justify-center gap-4">
+              <Link to="/empresas" className="inline-flex items-center rounded-full bg-primary-700 px-5 py-2 text-sm font-semibold text-white transition hover:bg-primary-600">
+                Ver todas as empresas
+              </Link>
+              {category && (
+                <Link
+                  to={`/empresas/${category.slug || category.id}`}
+                  className="inline-flex items-center rounded-full border border-primary-200 px-5 py-2 text-sm font-semibold text-primary-700 transition hover:border-primary-300 hover:text-primary-800"
+                >
+                  Voltar para {category.name}
+                </Link>
+              )}
+            </div>
+          </div>
+        </Container>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -64,6 +64,7 @@ type CategoryCard = {
   description: string;
   companiesLabel: string;
   image: string;
+  href: string;
 };
 
 const fallbackCategoryCards: CategoryCard[] = [
@@ -141,10 +142,14 @@ export default function HomePage() {
         ? category.description
         : 'Conheça o mix de empresas que oferecem serviços completos para o seu dia a dia.',
     companiesLabel: formatCompaniesLabel(category.companies?.length ?? 0),
-    image: categoryImages[index % categoryImages.length]
+    image: category.cardImage ?? category.heroImage ?? categoryImages[index % categoryImages.length],
+    href: `/empresas/${category.slug || category.id}`
   }));
 
-  const categoryCards: CategoryCard[] = dynamicCategoryCards.length > 0 ? dynamicCategoryCards : fallbackCategoryCards;
+  const categoryCards: CategoryCard[] =
+    dynamicCategoryCards.length > 0
+      ? dynamicCategoryCards
+      : fallbackCategoryCards.map((card) => ({ ...card, href: '/empresas' }));
 
   return (
     <div className="space-y-24 pb-24">
@@ -287,7 +292,7 @@ export default function HomePage() {
                   <h3 className="text-xl font-semibold text-primary-800">{card.title}</h3>
                   <p className="flex-1 text-sm text-[#4f5d55]">{card.description}</p>
                   <Link
-                    to="/empresas"
+                    to={card.href}
                     className="inline-flex items-center text-sm font-semibold text-primary-600 transition-colors hover:text-accent-500"
                   >
                     Ver empresas


### PR DESCRIPTION
## Summary
- add an Empresas landing page that highlights each business segment hosted in the center
- create segment and company detail pages backed by richer category metadata and galleries
- refresh the home page and navigation links so visitors can browse directly to each sector

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1d8406f18833088b3510d61a9702d