### PR TITLE
Fix address normalization for formatted fields

### DIFF
--- a/backend/src/services/companies-service.js
+++ b/backend/src/services/companies-service.js
@@ -163,6 +163,41 @@ function pickFirst(row, candidates, fallback = '') {
   return fallback;
 }
 
+function pickFirstValue(row, candidates) {
+  for (const candidate of candidates) {
+    if (!Object.prototype.hasOwnProperty.call(row, candidate)) {
+      continue;
+    }
+
+    const value = row[candidate];
+
+    if (value === null || value === undefined) {
+      continue;
+    }
+
+    if (typeof value === 'string') {
+      const normalized = ensureString(value, '');
+      if (normalized) {
+        return { key: candidate, value };
+      }
+
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        return { key: candidate, value };
+      }
+
+      continue;
+    }
+
+    return { key: candidate, value };
+  }
+
+  return { key: null, value: null };
+}
+
 function pickList(row, candidates) {
   for (const candidate of candidates) {
     if (Object.prototype.hasOwnProperty.call(row, candidate)) {
@@ -328,6 +363,8 @@ function mapRowToCompany(tableId, row, index) {
   const galleryKey = getFirstExistingKey(row, COMPANY_FIELD_CANDIDATES.gallery);
   const highlightKey = getFirstExistingKey(row, COMPANY_FIELD_CANDIDATES.highlight);
 
+  const { value: addressValue } = pickFirstValue(row, COMPANY_FIELD_CANDIDATES.address);
+
   const company = {
     id,
     slug,
@@ -342,7 +379,7 @@ function mapRowToCompany(tableId, row, index) {
     instagram: pickFirst(row, COMPANY_FIELD_CANDIDATES.instagram, ''),
     facebook: pickFirst(row, COMPANY_FIELD_CANDIDATES.facebook, ''),
     linkedin: pickFirst(row, COMPANY_FIELD_CANDIDATES.linkedin, ''),
-    address: normalizeAddress(pickFirst(row, COMPANY_FIELD_CANDIDATES.address, '')),
+    address: normalizeAddress(addressValue ?? ''),
     mapsUrl: pickFirst(row, COMPANY_FIELD_CANDIDATES.mapsUrl, ''),
     schedule: pickFirst(row, COMPANY_FIELD_CANDIDATES.schedule, ''),
     services: pickList(row, COMPANY_FIELD_CANDIDATES.services),
@@ -385,3 +422,9 @@ export async function fetchCompanyCategories() {
 
   return { categories, generatedAt };
 }
+
+export const __test__ = {
+  mapRowToCompany,
+  normalizeAddress,
+  pickFirstValue
+};

--- a/backend/test/companies-service.test.js
+++ b/backend/test/companies-service.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __test__ } from '../src/services/companies-service.js';
+
+const { mapRowToCompany } = __test__;
+
+test('mapRowToCompany preserves formatted address information', () => {
+  const row = {
+    id: 'company-1',
+    titulo: 'Example Company',
+    endereco: {
+      formatted: 'Avenida Paulista, 1000 - São Paulo/SP',
+      description: 'Should prefer formatted field when present'
+    }
+  };
+
+  const company = mapRowToCompany('test-category', row, 0);
+
+  assert.equal(
+    company.address,
+    'Avenida Paulista, 1000 - São Paulo/SP',
+    'formatted address should surface in the mapped company'
+  );
+});


### PR DESCRIPTION
## Summary
- add a helper to preserve non-string address values before normalization
- ensure company mapping passes structured address objects to the normalizer and expose internals for testing
- add a regression test covering rows with endereco.formatted values

## Testing
- node --test backend/test/companies-service.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2712a76ac8330a134db298bb542a5