### PR TITLE
Sync company categories with config and add API tests

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -43,9 +43,12 @@ app.get('*', (req, res, next) => {
 });
 
 const port = process.env.PORT ? Number(process.env.PORT) : 3333;
-app.listen(port, () => {
-  // eslint-disable-next-line no-console
-  console.log(`Server listening on port ${port}`);
-});
+
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Server listening on port ${port}`);
+  });
+}
 
 export default app;

--- a/backend/lib/categories.js
+++ b/backend/lib/categories.js
@@ -1,9 +1,10 @@
-export const CATEGORIES = [
-  { name: 'Administração', slug: 'administracao', table: 'administracao' },
-  { name: 'Advocacia', slug: 'advocacia', table: 'advocacia' },
-  { name: 'Beleza', slug: 'beleza', table: 'beleza' },
-  { name: 'Contabilidade', slug: 'contabilidade', table: 'contabilidade' },
-  { name: 'Imobiliária', slug: 'imobiliaria', table: 'imobiliaria' },
-];
+import { COMPANY_CATEGORIES } from '../src/config/company-categories.js';
+
+export const CATEGORIES = COMPANY_CATEGORIES.map((category) => ({
+  ...category,
+  slug: category.slug ?? category.id,
+}));
 
 export const bySlug = Object.fromEntries(CATEGORIES.map((category) => [category.slug, category]));
+
+export { COMPANY_CATEGORIES };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,7 +20,31 @@
         "stripe": "^14.24.0"
       },
       "devDependencies": {
-        "nodemon": "^3.1.4"
+        "nodemon": "^3.1.4",
+        "supertest": "^7.1.4"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@types/node": {
@@ -63,6 +87,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -243,6 +274,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -325,6 +366,13 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -382,6 +430,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -531,6 +590,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -596,6 +662,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -1164,6 +1248,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1499,6 +1593,79 @@
         "node": ">=12.*"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -1596,6 +1763,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,10 +21,11 @@
     "helmet": "^7.1.0",
     "mysql2": "^3.9.7",
     "node-cache": "^5.1.2",
-    "stripe": "^14.24.0",
-    "slugify": "^1.6.6"
+    "slugify": "^1.6.6",
+    "stripe": "^14.24.0"
   },
   "devDependencies": {
-    "nodemon": "^3.1.4"
+    "nodemon": "^3.1.4",
+    "supertest": "^7.1.4"
   }
 }

--- a/backend/routes/companies.js
+++ b/backend/routes/companies.js
@@ -1,13 +1,18 @@
 import express from 'express';
 
 import pool from '../db/pool.js';
-import { bySlug } from '../lib/categories.js';
+import { CATEGORIES, bySlug } from '../lib/categories.js';
 import { pickCompanyFields } from '../lib/normalize.js';
 
 const router = express.Router();
+const knownCategoryTables = new Set(CATEGORIES.map((category) => category.table));
 const columnCache = new Map();
 
 async function getTableColumns(table) {
+  if (!knownCategoryTables.has(table)) {
+    return [];
+  }
+
   if (columnCache.has(table)) {
     return columnCache.get(table);
   }

--- a/backend/test/companies.test.js
+++ b/backend/test/companies.test.js
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test, { after, mock } from 'node:test';
+import request from 'supertest';
+
+import { CATEGORIES } from '../lib/categories.js';
+
+const originalNodeEnv = process.env.NODE_ENV;
+process.env.NODE_ENV = 'test';
+process.env.DB_NAME = process.env.DB_NAME ?? 'test_database';
+
+after(() => {
+  process.env.NODE_ENV = originalNodeEnv;
+});
+
+const { default: pool } = await import('../db/pool.js');
+const { default: app } = await import('../app.js');
+
+const fixturesByTable = Object.fromEntries(
+  CATEGORIES.map((category, index) => {
+    const columns = ['id', 'titulo', 'descricao', 'updated_at', 'status_col'];
+    const row = {
+      id: index + 1,
+      titulo: `${category.name} Example`,
+      descricao: `Description for ${category.name}`,
+      updated_at: '2024-01-01',
+      status_col: 'published',
+    };
+
+    return [
+      category.table,
+      {
+        columns,
+        rows: [row],
+      },
+    ];
+  })
+);
+
+test('GET /api/companies resolves each category list and detail', async (t) => {
+  const queryMock = mock.method(pool, 'query', async (sql, params = []) => {
+    if (typeof sql === 'string' && sql.includes('information_schema.columns')) {
+      const tableName = params?.[1];
+      const fixture = fixturesByTable[tableName];
+      const columns = fixture?.columns ?? [];
+      return [columns.map((column) => ({ column_name: column })), []];
+    }
+
+    const tableMatch = typeof sql === 'string' ? sql.match(/FROM\s+`([^`]+)`/i) : null;
+    const tableName = tableMatch?.[1];
+    const fixture = tableName ? fixturesByTable[tableName] : undefined;
+
+    if (!fixture) {
+      return [[{ total: 0 }], []];
+    }
+
+    if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
+      return [[{ total: fixture.rows.length }], []];
+    }
+
+    if (typeof sql === 'string' && sql.includes('LIMIT 1')) {
+      const idParam = params?.[0];
+      const row = fixture.rows.find((item) => String(item.id ?? item.pk) === String(idParam));
+      return [row ? [row] : [], []];
+    }
+
+    return [fixture.rows, []];
+  });
+
+  t.after(() => {
+    queryMock.mock.restore();
+  });
+
+  for (const category of CATEGORIES) {
+    const fixture = fixturesByTable[category.table];
+
+    const listResponse = await request(app)
+      .get('/api/companies')
+      .query({ category: category.slug });
+
+    assert.equal(listResponse.status, 200, `List request for ${category.slug} should succeed`);
+    assert.equal(listResponse.body.total, fixture.rows.length);
+    assert.equal(listResponse.body.items.length, fixture.rows.length);
+    assert.equal(listResponse.body.items[0].category, category.slug);
+    assert.equal(listResponse.body.items[0].name, fixture.rows[0].titulo);
+
+    const detailResponse = await request(app)
+      .get(`/api/companies/${category.slug}/${fixture.rows[0].id}`)
+      .query();
+
+    assert.equal(detailResponse.status, 200, `Detail request for ${category.slug} should succeed`);
+    assert.equal(detailResponse.body.id, fixture.rows[0].id);
+    assert.equal(detailResponse.body.category, category.slug);
+    assert.equal(detailResponse.body.name, fixture.rows[0].titulo);
+  }
+});


### PR DESCRIPTION
## Summary
- derive the backend category map from the shared company categories config so every slug is available
- update the companies router to validate requested tables against the unified category list and support test execution
- add supertest-based coverage that exercises the companies list and detail endpoints for every category

## Testing
- node --test backend/test/companies.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2712b30a48330923064d35da01a13