### PR TITLE
Fix default database name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Este projeto reúne o backend Express e o frontend React/Vite do site institucio
 | `DB_PORT`              | Porta do MySQL                                                            | `3306`                |
 | `DB_USER`              | Usuário do banco                                                          | `root`                |
 | `DB_PASSWORD`          | Senha do banco                                                            | `""`                 |
-| `DB_NAME`              | Nome do schema                                                            | `jaguar_center_plaza` |
+| `DB_NAME`              | Nome do schema                                                            | `JaguarPlaza`         |
 | `DB_CONN_LIMIT`        | Máximo de conexões simultâneas                                            | `10`                  |
 | `PUBLIC_BASE_URL`      | URL base pública usada para montar links absolutos                        | —                     |
 | `PORT`                 | Porta HTTP do Express                                                     | `3333`                |

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -46,7 +46,7 @@ export const env = {
     port: toNumber(process.env.DB_PORT, 3306),
     user: process.env.DB_USER || 'root',
     password: process.env.DB_PASSWORD || '',
-    name: process.env.DB_NAME || 'jaguar_center_plaza',
+    name: process.env.DB_NAME || 'JaguarPlaza',
     connectionLimit: toNumber(process.env.DB_CONN_LIMIT, 10)
   },
   security: {


### PR DESCRIPTION
## Summary
- set the backend's default MySQL schema to JaguarPlaza so it matches the production database
- update the environment variable documentation to reflect the new default schema name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e276919dc483308cabe005a1caf1c7