### PR TITLE
Refactor backend server to support modular API

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,54 +1,9 @@
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { createApp, startServer } from './src/server.js';
 
-import cors from 'cors';
-import dotenv from 'dotenv';
-import express from 'express';
-import helmet from 'helmet';
-
-import categoriesRouter from './routes/categories.js';
-import companiesRouter from './routes/companies.js';
-
-dotenv.config();
-
-const app = express();
-
-app.use(helmet());
-app.use(cors());
-app.use(express.json());
-
-app.use('/api', categoriesRouter);
-app.use('/api', companiesRouter);
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const distDir = path.resolve(__dirname, '../frontend/dist');
-const indexFile = path.join(distDir, 'index.html');
-
-if (fs.existsSync(distDir)) {
-  app.use(express.static(distDir));
-}
-
-app.get('*', (req, res, next) => {
-  if (req.path.startsWith('/api/')) {
-    return next();
-  }
-
-  if (!fs.existsSync(indexFile)) {
-    return res.status(404).send('Frontend build not found');
-  }
-
-  return res.sendFile(indexFile);
-});
-
-const port = process.env.PORT ? Number(process.env.PORT) : 3333;
+const app = createApp();
 
 if (process.env.NODE_ENV !== 'test') {
-  app.listen(port, () => {
-    // eslint-disable-next-line no-console
-    console.log(`Server listening on port ${port}`);
-  });
+  startServer(app);
 }
 
 export default app;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -6,6 +6,7 @@ import cors from 'cors';
 import express from 'express';
 import helmet from 'helmet';
 
+import companiesRouter from '../routes/companies.js';
 import { env, resolvePublicBaseUrl } from './config/env.js';
 import { errorHandler } from './middleware/error-handler.js';
 import apiRouter from './routes/index.js';
@@ -16,53 +17,62 @@ const __dirname = path.dirname(__filename);
 const distDir = path.resolve(__dirname, '../dist');
 const indexFile = path.join(distDir, 'index.html');
 
-const app = express();
+export function createApp() {
+  const app = express();
 
-if (env.security.trustProxy) {
-  app.set('trust proxy', 1);
+  if (env.security.trustProxy) {
+    app.set('trust proxy', 1);
+  }
+
+  app.use(helmet());
+  app.use(cors());
+  app.use(compression());
+  app.use(express.json({ limit: '1mb' }));
+  app.use(express.urlencoded({ extended: true }));
+
+  app.get('/sitemap.xml', async (req, res, next) => {
+    try {
+      const baseUrl = resolvePublicBaseUrl(req);
+      const { gzip } = await getSitemap(baseUrl);
+
+      res.setHeader('Content-Type', 'application/xml');
+      res.setHeader('Content-Encoding', 'gzip');
+      res.send(gzip);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.use('/api', apiRouter);
+  app.use('/api', companiesRouter);
+
+  if (fs.existsSync(distDir)) {
+    app.use(express.static(distDir, { index: false, maxAge: env.nodeEnv === 'production' ? '1h' : 0 }));
+  }
+
+  app.get('*', (req, res, next) => {
+    if (req.path.startsWith('/api/')) {
+      return next();
+    }
+
+    if (!fs.existsSync(indexFile)) {
+      return res.status(404).send('Aplicação frontend não encontrada. Execute o build antes de iniciar o servidor.');
+    }
+
+    return res.sendFile(indexFile);
+  });
+
+  app.use(errorHandler);
+
+  return app;
 }
 
-app.use(helmet());
-app.use(cors());
-app.use(compression());
-app.use(express.json({ limit: '1mb' }));
-app.use(express.urlencoded({ extended: true }));
-
-app.get('/sitemap.xml', async (req, res, next) => {
-  try {
-    const baseUrl = resolvePublicBaseUrl(req);
-    const { gzip } = await getSitemap(baseUrl);
-
-    res.setHeader('Content-Type', 'application/xml');
-    res.setHeader('Content-Encoding', 'gzip');
-    res.send(gzip);
-  } catch (error) {
-    next(error);
-  }
-});
-
-app.use('/api', apiRouter);
-
-if (fs.existsSync(distDir)) {
-  app.use(express.static(distDir, { index: false, maxAge: env.nodeEnv === 'production' ? '1h' : 0 }));
+export function startServer(app = createApp()) {
+  const port = env.port;
+  return app.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Servidor iniciado na porta ${port}`);
+  });
 }
 
-app.get('*', (req, res, next) => {
-  if (req.path.startsWith('/api/')) {
-    return next();
-  }
-
-  if (!fs.existsSync(indexFile)) {
-    return res.status(404).send('Aplicação frontend não encontrada. Execute o build antes de iniciar o servidor.');
-  }
-
-  res.sendFile(indexFile);
-});
-
-app.use(errorHandler);
-
-const port = env.port;
-app.listen(port, () => {
-  // eslint-disable-next-line no-console
-  console.log(`Servidor iniciado na porta ${port}`);
-});
+export default createApp;


### PR DESCRIPTION
## Summary
- refactor the backend entry point to reuse the shared server bootstrap
- expose reusable server creation/start helpers and mount the legacy companies router alongside the new API routes
- clean up the company normalizer to remove duplicated code, dedupe contacts, and preserve record identifiers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3a3b1d4d4833080e8c5d994c9e18b