### PR TITLE
Allow company endpoints to accept multiple published statuses

### DIFF
--- a/backend/routes/companies.js
+++ b/backend/routes/companies.js
@@ -3,6 +3,7 @@ import express from 'express';
 import pool from '../db/pool.js';
 import { CATEGORIES, bySlug } from '../lib/categories.js';
 import { pickCompanyFields } from '../lib/normalize.js';
+import { buildPublicationStatusClause } from '../src/utils/publication-status.js';
 
 const router = express.Router();
 const knownCategoryTables = new Set(CATEGORIES.map((category) => category.table));
@@ -120,9 +121,9 @@ function buildPublicationFilters(categoryInfo, columnLookup, params) {
   const filters = [];
 
   const statusColumn = resolveColumn(columnLookup, categoryInfo.statusColumn);
-  if (statusColumn) {
-    filters.push(`\`${statusColumn}\` = ?`);
-    params.push('PUBLISHED');
+  const statusClause = buildPublicationStatusClause(statusColumn);
+  if (statusClause) {
+    filters.push(statusClause);
   }
 
   const publishDateColumn = resolveColumn(columnLookup, categoryInfo.publishDateColumn);

--- a/backend/src/services/companies-service.js
+++ b/backend/src/services/companies-service.js
@@ -1,14 +1,13 @@
 import { COMPANY_CATEGORIES } from '../config/company-categories.js';
 import { query } from '../database/pool.js';
+import { buildPublicationStatusClause } from '../utils/publication-status.js';
 import { extractLatestDate, normalizeCompanyRow } from './company-normalizer.js';
 
 async function fetchRowsForCategory(config) {
   const conditions = [];
-  const params = {};
 
   if (config.statusColumn) {
-    conditions.push(`\`${config.statusColumn}\` = :status`);
-    params.status = 'PUBLISHED';
+    conditions.push(buildPublicationStatusClause(config.statusColumn));
   }
 
   if (config.publishDateColumn) {
@@ -24,7 +23,7 @@ async function fetchRowsForCategory(config) {
   const sql = `SELECT * FROM \`${tableName}\` ${whereClause} LIMIT 500`;
 
   try {
-    const rows = await query(sql, params);
+    const rows = await query(sql);
     return Array.isArray(rows) ? rows : [];
   } catch (error) {
     console.error(`Falha ao consultar a tabela ${tableName}`, error);

--- a/backend/src/utils/publication-status.js
+++ b/backend/src/utils/publication-status.js
@@ -1,0 +1,30 @@
+const ALLOWED_STATUS_VALUES = [
+  'published',
+  'publicado',
+  'active',
+  'ativo',
+  '1',
+  'true',
+  'sim',
+  'yes'
+];
+
+function escapeColumnName(column) {
+  return String(column).replace(/`/g, '');
+}
+
+export function buildPublicationStatusClause(column) {
+  if (!column) {
+    return '';
+  }
+
+  const safeColumn = escapeColumnName(column);
+  const allowedValues = ALLOWED_STATUS_VALUES.map((value) => `'${value}'`).join(', ');
+
+  return `LOWER(COALESCE(CAST(\`${safeColumn}\` AS CHAR), '')) IN (${allowedValues})`;
+}
+
+export const __test__ = {
+  ALLOWED_STATUS_VALUES,
+  escapeColumnName
+};


### PR DESCRIPTION
## Summary
- add a shared helper to build publication status clauses that accept multiple truthy values
- update the company category service and routes to rely on the broader status filter for database queries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3a74d57f08330b0a97c1177faa3a5