### PR TITLE
Harden category endpoints against metadata failures

### DIFF
--- a/backend/routes/companies.js
+++ b/backend/routes/companies.js
@@ -8,6 +8,55 @@ import { buildPublicationStatusClause } from '../src/utils/publication-status.js
 const router = express.Router();
 const knownCategoryTables = new Set(CATEGORIES.map((category) => category.table));
 const columnCache = new Map();
+const FALLBACK_COLUMNS = null;
+const STATUS_VALUES = new Set([
+  'published',
+  'publicado',
+  'publicada',
+  'active',
+  'ativo',
+  'ativa',
+  '1',
+  'true',
+  'sim',
+  'yes',
+]);
+
+function mapRowsToCompanies(rows, categoryInfo, startIndex = 0) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return [];
+  }
+
+  return rows.map((row, index) =>
+    pickCompanyFields(row, categoryInfo.slug, categoryInfo.table, startIndex + index)
+  );
+}
+
+function toListItem(normalized) {
+  return {
+    id: normalized.id,
+    slug: normalized.slug,
+    category: normalized.category,
+    name: normalized.name,
+    description: normalized.description,
+    shortDescription: normalized.shortDescription,
+    logo: normalized.logo,
+    coverImage: normalized.coverImage,
+    address: normalized.address,
+    room: normalized.room,
+    phone: normalized.phone,
+    phones: normalized.phones,
+    email: normalized.email,
+    emails: normalized.emails,
+    whatsapp: normalized.whatsapp,
+    instagram: normalized.instagram,
+    facebook: normalized.facebook,
+    website: normalized.website,
+    detailPath: normalized.detailPath,
+    listPath: normalized.listPath,
+    highlight: normalized.highlight,
+  };
+}
 
 function createColumnLookup(columns = []) {
   const lookup = new Map();
@@ -38,23 +87,109 @@ async function getTableColumns(table) {
 
   const database = process.env.DB_NAME;
   if (!database) {
-    columnCache.set(table, []);
-    return [];
+    columnCache.set(table, FALLBACK_COLUMNS);
+    return FALLBACK_COLUMNS;
   }
 
-  const [rows] = await pool.query(
-    'SELECT column_name FROM information_schema.columns WHERE table_schema = ? AND table_name = ?',
-    [database, table]
-  );
+  try {
+    const [rows] = await pool.query(
+      'SELECT column_name FROM information_schema.columns WHERE table_schema = ? AND table_name = ?',
+      [database, table]
+    );
 
-  const columns = Array.isArray(rows)
-    ? rows
-        .map((row) => row.column_name || row.COLUMN_NAME)
-        .filter((name) => typeof name === 'string' && name.length > 0)
-    : [];
+    const columns = Array.isArray(rows)
+      ? rows
+          .map((row) => row.column_name || row.COLUMN_NAME)
+          .filter((name) => typeof name === 'string' && name.length > 0)
+      : [];
 
-  columnCache.set(table, columns);
-  return columns;
+    columnCache.set(table, columns);
+    return columns;
+  } catch (error) {
+    console.warn(`Unable to inspect columns for table ${table}`, error);
+    columnCache.set(table, FALLBACK_COLUMNS);
+    return FALLBACK_COLUMNS;
+  }
+}
+
+async function fetchCategoryItems(categoryInfo, limit = 500) {
+  const columns = await getTableColumns(categoryInfo.table);
+
+  if (Array.isArray(columns) && columns.length > 0) {
+    const columnLookup = createColumnLookup(columns);
+    const params = [];
+    const filters = buildPublicationFilters(categoryInfo, columnLookup, params);
+    const filtersSql = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    const orderClause = resolveOrderClause(columnLookup);
+
+    const [rows] = await pool.query(
+      `SELECT * FROM \`${categoryInfo.table}\` ${filtersSql} ${orderClause} LIMIT ?`,
+      [...params, limit]
+    );
+
+    return mapRowsToCompanies(rows, categoryInfo);
+  }
+
+  const [rows] = await pool.query(`SELECT * FROM \`${categoryInfo.table}\` LIMIT ?`, [limit]);
+  const filtered = rows.filter((row) => isRowPublished(row, categoryInfo));
+  return mapRowsToCompanies(filtered, categoryInfo);
+}
+
+function getRowValue(row, ...candidates) {
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+
+  const lookup = new Map();
+  for (const key of Object.keys(row)) {
+    lookup.set(key.toLowerCase(), key);
+  }
+
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+
+    const key = lookup.get(String(candidate).toLowerCase());
+    if (key) {
+      return row[key];
+    }
+  }
+
+  return null;
+}
+
+function parseDate(value) {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function isRowPublished(row, categoryInfo) {
+  const statusValue = getRowValue(row, categoryInfo.statusColumn, 'status', 'status_col');
+  if (statusValue !== null && statusValue !== undefined) {
+    const normalized = String(statusValue).trim().toLowerCase();
+    if (normalized && !STATUS_VALUES.has(normalized)) {
+      return false;
+    }
+  }
+
+  const publishDateValue = getRowValue(row, categoryInfo.publishDateColumn, 'publish_date', 'publish_at');
+  const publishDate = parseDate(publishDateValue);
+  if (publishDate && publishDate.getTime() > Date.now()) {
+    return false;
+  }
+
+  const unpublishDateValue = getRowValue(row, categoryInfo.unpublishDateColumn, 'unpublish_date', 'unpublish_at');
+  const unpublishDate = parseDate(unpublishDateValue);
+  if (unpublishDate && unpublishDate.getTime() <= Date.now()) {
+    return false;
+  }
+
+  return true;
 }
 
 function buildSearchClause(columnLookup, searchTerm, params) {
@@ -167,83 +302,72 @@ router.get('/companies', async (req, res) => {
 
   try {
     const columns = await getTableColumns(categoryInfo.table);
-
-    if (!columns.length) {
-      return res.status(404).json({ error: 'Category data not available' });
-    }
-
-    const columnLookup = createColumnLookup(columns);
-
     const pageNumber = normalizePage(page, 1);
     const size = Math.min(normalizePage(pageSize, 12), 100);
     const offset = (pageNumber - 1) * size;
-
     const searchTerm = typeof q === 'string' ? q.trim() : '';
-    const searchParams = [];
-    const filters = [];
 
-    const searchClause = buildSearchClause(columnLookup, searchTerm, searchParams);
-    if (searchClause) {
-      filters.push(searchClause);
+    if (Array.isArray(columns) && columns.length > 0) {
+      const columnLookup = createColumnLookup(columns);
+
+      const searchParams = [];
+      const filters = [];
+
+      const searchClause = buildSearchClause(columnLookup, searchTerm, searchParams);
+      if (searchClause) {
+        filters.push(searchClause);
+      }
+
+      const whereParams = [...searchParams];
+      const publicationFilters = buildPublicationFilters(categoryInfo, columnLookup, whereParams);
+      if (publicationFilters.length) {
+        filters.push(...publicationFilters);
+      }
+
+      const filtersSql = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+
+      const [countRows] = await pool.query(
+        `SELECT COUNT(*) AS total FROM \`${categoryInfo.table}\` ${filtersSql}`,
+        whereParams
+      );
+
+      const total = Number(countRows?.[0]?.total ?? countRows?.[0]?.c ?? 0);
+      const orderClause = resolveOrderClause(columnLookup);
+
+      const [rows] = await pool.query(
+        `SELECT * FROM \`${categoryInfo.table}\` ${filtersSql} ${orderClause} LIMIT ? OFFSET ?`,
+        [...whereParams, size, offset]
+      );
+
+      const items = mapRowsToCompanies(rows, categoryInfo, offset).map(toListItem);
+
+      return res.json({ page: pageNumber, pageSize: size, total, items });
     }
 
-    const whereParams = [...searchParams];
-    const publicationFilters = buildPublicationFilters(categoryInfo, columnLookup, whereParams);
-    if (publicationFilters.length) {
-      filters.push(...publicationFilters);
+    const [rows] = await pool.query(`SELECT * FROM \`${categoryInfo.table}\``);
+    const publishedRows = rows.filter((row) => isRowPublished(row, categoryInfo));
+    let normalizedRows = mapRowsToCompanies(publishedRows, categoryInfo);
+
+    if (searchTerm) {
+      const term = searchTerm.toLowerCase();
+      normalizedRows = normalizedRows.filter((company) => {
+        const fields = [
+          company.name,
+          company.shortDescription,
+          company.description,
+          company.address,
+        ];
+
+        return fields.some(
+          (value) => typeof value === 'string' && value.toLowerCase().includes(term)
+        );
+      });
     }
 
-    const filtersSql = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    const total = normalizedRows.length;
+    const paginated = normalizedRows.slice(offset, offset + size).map(toListItem);
 
-    const [countRows] = await pool.query(
-      `SELECT COUNT(*) AS total FROM \`${categoryInfo.table}\` ${filtersSql}`,
-      whereParams
-    );
-
-    const total = Number(countRows?.[0]?.total ?? countRows?.[0]?.c ?? 0);
-    const orderClause = resolveOrderClause(columnLookup);
-
-    const [rows] = await pool.query(
-      `SELECT * FROM \`${categoryInfo.table}\` ${filtersSql} ${orderClause} LIMIT ? OFFSET ?`,
-      [...whereParams, size, offset]
-    );
-
-    const items = Array.isArray(rows)
-      ? rows.map((row, index) => {
-          const normalized = pickCompanyFields(
-            row,
-            categoryInfo.slug,
-            categoryInfo.table,
-            offset + index
-          );
-
-          return {
-            id: normalized.id,
-            slug: normalized.slug,
-            category: normalized.category,
-            name: normalized.name,
-            description: normalized.description,
-            shortDescription: normalized.shortDescription,
-            logo: normalized.logo,
-            coverImage: normalized.coverImage,
-            address: normalized.address,
-            room: normalized.room,
-            phone: normalized.phone,
-            phones: normalized.phones,
-            email: normalized.email,
-            emails: normalized.emails,
-            whatsapp: normalized.whatsapp,
-            instagram: normalized.instagram,
-            facebook: normalized.facebook,
-            website: normalized.website,
-            detailPath: normalized.detailPath,
-            listPath: normalized.listPath,
-            highlight: normalized.highlight,
-          };
-        })
-      : [];
-
-    res.json({ page: pageNumber, pageSize: size, total, items });
+    res.json({ page: pageNumber, pageSize: size, total, items: paginated });
   } catch (error) {
     console.error('Failed to list companies', error);
     res.status(500).json({ error: 'Failed to list companies' });
@@ -262,29 +386,48 @@ router.get('/companies/:category/:id', async (req, res) => {
   try {
     const columns = await getTableColumns(categoryInfo.table);
 
-    if (!columns.length) {
-      return res.status(404).json({ error: 'Category data not available' });
+    if (Array.isArray(columns) && columns.length > 0) {
+      const columnLookup = createColumnLookup(columns);
+      const params = [];
+      const filters = buildPublicationFilters(categoryInfo, columnLookup, params);
+      const filtersSql = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+      const orderClause = resolveOrderClause(columnLookup);
+
+      const [rows] = await pool.query(
+        `SELECT * FROM \`${categoryInfo.table}\` ${filtersSql} ${orderClause} LIMIT 500`,
+        params
+      );
+
+      if (!Array.isArray(rows) || rows.length === 0) {
+        return res.status(404).json({ error: 'Company not found' });
+      }
+
+      const normalizedRows = mapRowsToCompanies(rows, categoryInfo);
+
+      const target = String(id).toLowerCase();
+      const match = normalizedRows.find((company) => {
+        const companyId = company.id ? String(company.id).toLowerCase() : null;
+        const companySlug = company.slug ? String(company.slug).toLowerCase() : null;
+        return companyId === target || companySlug === target;
+      });
+
+      if (!match) {
+        return res.status(404).json({ error: 'Company not found' });
+      }
+
+      return res.json(match);
     }
 
-    const columnLookup = createColumnLookup(columns);
-    const params = [];
-    const filters = buildPublicationFilters(categoryInfo, columnLookup, params);
-    const filtersSql = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
-    const orderClause = resolveOrderClause(columnLookup);
-
     const [rows] = await pool.query(
-      `SELECT * FROM \`${categoryInfo.table}\` ${filtersSql} ${orderClause} LIMIT 500`,
-      params
+      `SELECT * FROM \`${categoryInfo.table}\` LIMIT 500`
     );
 
     if (!Array.isArray(rows) || rows.length === 0) {
       return res.status(404).json({ error: 'Company not found' });
     }
 
-    const normalizedRows = rows.map((row, index) =>
-      pickCompanyFields(row, categoryInfo.slug, categoryInfo.table, index)
-    );
-
+    const publishedRows = rows.filter((row) => isRowPublished(row, categoryInfo));
+    const normalizedRows = mapRowsToCompanies(publishedRows, categoryInfo);
     const target = String(id).toLowerCase();
     const match = normalizedRows.find((company) => {
       const companyId = company.id ? String(company.id).toLowerCase() : null;
@@ -302,5 +445,17 @@ router.get('/companies/:category/:id', async (req, res) => {
     res.status(500).json({ error: 'Failed to fetch company details' });
   }
 });
+
+for (const categoryInfo of CATEGORIES) {
+  router.get(`/${categoryInfo.slug}`, async (_req, res) => {
+    try {
+      const items = await fetchCategoryItems(categoryInfo);
+      res.json(items);
+    } catch (error) {
+      console.error(`Failed to list companies for category ${categoryInfo.slug}`, error);
+      res.status(500).json({ error: 'Failed to list companies' });
+    }
+  });
+}
 
 export default router;

--- a/backend/src/config/company-categories.js
+++ b/backend/src/config/company-categories.js
@@ -5,7 +5,7 @@
     name: 'Administração',
     description:
       'Consultorias, BPOs e administradoras que apoiam a estruturação financeira e operacional dos negócios residentes.',
-    statusColumn: 'status_col',
+    statusColumn: 'status',
     publishDateColumn: 'publish_date',
     unpublishDateColumn: 'unpublish_date'
   },
@@ -15,7 +15,9 @@
     name: 'Advocacia',
     description:
       'Escritórios jurídicos e especialistas em consultivo e contencioso empresarial com atendimento personalizado.',
-    statusColumn: 'status_col'
+    statusColumn: 'status',
+    publishDateColumn: 'publish_date',
+    unpublishDateColumn: 'unpublish_date'
   },
   {
     id: 'beleza',
@@ -23,7 +25,9 @@
     name: 'Beleza & Bem-estar',
     description:
       'Salões, barbearias e estúdios de bem-estar que oferecem experiências completas de autocuidado.',
-    statusColumn: 'status_col'
+    statusColumn: 'status',
+    publishDateColumn: 'publish_date',
+    unpublishDateColumn: 'unpublish_date'
   },
   {
     id: 'contabilidade',
@@ -31,7 +35,9 @@
     name: 'Contabilidade & Finanças',
     description:
       'Profissionais e empresas especializadas em contabilidade consultiva, BPO financeiro e controladoria.',
-    statusColumn: 'status_col'
+    statusColumn: 'status',
+    publishDateColumn: 'publish_date',
+    unpublishDateColumn: 'unpublish_date'
   },
   {
     id: 'imobiliaria',
@@ -39,7 +45,9 @@
     name: 'Imobiliárias & Condomínios',
     description:
       'Administradoras, corretores e serviços de gestão patrimonial e locação corporativa.',
-    statusColumn: 'status_col'
+    statusColumn: 'status',
+    publishDateColumn: 'publish_date',
+    unpublishDateColumn: 'unpublish_date'
   },
   {
     id: 'industrias',
@@ -47,7 +55,9 @@
     name: 'Indústrias & Serviços Técnicos',
     description:
       'Fornecedores técnicos e industriais que atendem demandas produtivas e de manutenção especializada.',
-    statusColumn: 'status_col'
+    statusColumn: 'status',
+    publishDateColumn: 'publish_date',
+    unpublishDateColumn: 'unpublish_date'
   },
   {
     id: 'lojas',
@@ -55,7 +65,7 @@
     name: 'Lojas & Conveniência',
     description:
       'Comércio, alimentação e conveniência para o dia a dia de quem frequenta o Jaguar Center Plaza.',
-    statusColumn: 'status_col',
+    statusColumn: 'status',
     publishDateColumn: 'publish_date',
     unpublishDateColumn: 'unpublish_date'
   }

--- a/backend/test/companies.test.js
+++ b/backend/test/companies.test.js
@@ -17,13 +17,13 @@ const { default: app } = await import('../app.js');
 
 const fixturesByTable = Object.fromEntries(
   CATEGORIES.map((category, index) => {
-    const columns = ['id', 'titulo', 'descricao', 'updated_at', 'status_col'];
+    const columns = ['id', 'titulo', 'descricao', 'updated_at', 'status'];
     const row = {
       id: index + 1,
       titulo: `${category.name} Example`,
       descricao: `Description for ${category.name}`,
       updated_at: '2024-01-01',
-      status_col: 'published',
+      status: 'published',
     };
 
     return [
@@ -83,6 +83,14 @@ test('GET /api/companies resolves each category list and detail', async (t) => {
     assert.equal(listResponse.body.items[0].category, category.slug);
     assert.equal(listResponse.body.items[0].name, fixture.rows[0].titulo);
 
+    const categoryResponse = await request(app).get(`/api/${category.slug}`);
+
+    assert.equal(categoryResponse.status, 200, `Category route for ${category.slug} should succeed`);
+    assert.ok(Array.isArray(categoryResponse.body), 'Category response should be an array');
+    assert.equal(categoryResponse.body.length, fixture.rows.length);
+    assert.equal(categoryResponse.body[0].category, category.slug);
+    assert.equal(categoryResponse.body[0].name, fixture.rows[0].titulo);
+
     const detailResponse = await request(app)
       .get(`/api/companies/${category.slug}/${fixture.rows[0].id}`)
       .query();
@@ -92,4 +100,53 @@ test('GET /api/companies resolves each category list and detail', async (t) => {
     assert.equal(detailResponse.body.category, category.slug);
     assert.equal(detailResponse.body.name, fixture.rows[0].titulo);
   }
+});
+
+test('category endpoints fall back gracefully when metadata inspection fails', async (t) => {
+  const row = {
+    id: 'fallback-id',
+    titulo: 'Fallback Example',
+    descricao: 'Example description',
+    endereco: 'Rua Teste, 123',
+    celular: '(19) 99999-9999',
+    status: 'published',
+    publish_date: null,
+    unpublish_date: null,
+  };
+
+  const queryMock = mock.method(pool, 'query', async (sql) => {
+    if (typeof sql === 'string' && sql.includes('information_schema.columns')) {
+      throw new Error('Access denied');
+    }
+
+    if (typeof sql === 'string' && sql.includes('COUNT(*)')) {
+      return [[{ total: 1 }], []];
+    }
+
+    return [[row], []];
+  });
+
+  t.after(() => {
+    queryMock.mock.restore();
+  });
+
+  const listResponse = await request(app)
+    .get('/api/companies')
+    .query({ category: 'administracao' });
+
+  assert.equal(listResponse.status, 200);
+  assert.equal(listResponse.body.total, 1);
+  assert.equal(listResponse.body.items[0].name, row.titulo);
+
+  const categoryResponse = await request(app).get('/api/administracao');
+
+  assert.equal(categoryResponse.status, 200);
+  assert.equal(categoryResponse.body.length, 1);
+  assert.equal(categoryResponse.body[0].name, row.titulo);
+
+  const detailResponse = await request(app).get('/api/companies/administracao/fallback-id');
+
+  assert.equal(detailResponse.status, 200);
+  assert.equal(detailResponse.body.id, row.id);
+  assert.equal(detailResponse.body.name, row.titulo);
 });


### PR DESCRIPTION
## Summary
- make the companies routes resilient when metadata inspection is unavailable by falling back to direct table queries
- align category configuration with the live schema so status and publication dates are detected correctly
- extend automated tests to cover the new fallback behaviour for list, detail and category endpoints

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68e3ab555a448330a1931b1e65fa0b98