### PR TITLE
Add frontend fallbacks for company categories and listings

### DIFF
--- a/frontend/src/api/companies.ts
+++ b/frontend/src/api/companies.ts
@@ -5,6 +5,33 @@ const client = axios.create({
   baseURL: baseUrl || '/api'
 });
 
+const FALLBACK_PATH = '/assets/categories-fallback.json';
+
+type FallbackCompany = {
+  id?: string | number;
+  slug?: string;
+  name?: string;
+  tagline?: string;
+  shortDescription?: string;
+  description?: string;
+  phones?: string[];
+  emails?: string[];
+  whatsapp?: string;
+  address?: string;
+  logo?: string;
+};
+
+type FallbackCategory = {
+  id?: string;
+  slug?: string;
+  name?: string;
+  companies?: FallbackCompany[];
+};
+
+type FallbackResponse = {
+  categories?: FallbackCategory[];
+};
+
 export type CategorySummary = {
   slug: string;
   label: string;
@@ -38,9 +65,190 @@ export type CompanyListResponse = {
   total: number;
 };
 
+let fallbackDataPromise: Promise<FallbackResponse> | null = null;
+
+async function loadFallbackData(): Promise<FallbackResponse> {
+  if (!fallbackDataPromise) {
+    fallbackDataPromise = fetch(FALLBACK_PATH, { cache: 'no-store' })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Falha ao carregar fallback ${FALLBACK_PATH}`);
+        }
+        return response.json() as Promise<FallbackResponse>;
+      })
+      .catch((error) => {
+        fallbackDataPromise = null;
+        throw error;
+      });
+  }
+
+  return fallbackDataPromise;
+}
+
+function labelFromSlug(slug: string) {
+  return slug
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function toCategorySummary(category: FallbackCategory): CategorySummary | null {
+  const slug = String(category.slug || category.id || '').trim();
+  if (!slug) {
+    return null;
+  }
+
+  const label = category.name?.trim() || labelFromSlug(slug);
+  const total = category.companies?.length ?? 0;
+
+  return { slug, label, total };
+}
+
+function extractRoom(address: string | undefined): string | null {
+  if (!address) {
+    return null;
+  }
+
+  const match = address.match(/sala\s+([\wº]+)/i);
+  if (!match) {
+    return null;
+  }
+
+  return match[1] ? match[1].toUpperCase() : match[0];
+}
+
+function toCompanyRecord(company: FallbackCompany): CompanyRecord {
+  const titulo = company.name?.trim() || company.slug?.trim() || null;
+  const descriptions = [company.shortDescription, company.description, company.tagline]
+    .map((item) => (item?.trim() ? item.trim() : ''))
+    .filter((item) => item.length > 0);
+  const descricao = descriptions[0] ?? null;
+  const address = company.address?.trim() || null;
+  const phones = Array.isArray(company.phones) ? company.phones : [];
+  const emails = Array.isArray(company.emails) ? company.emails : [];
+  const celular = phones.find((phone) => phone && phone.trim())?.trim() || company.whatsapp?.trim() || null;
+  const email = emails.find((value) => value && value.trim())?.trim() || null;
+
+  return {
+    id: company.id ?? company.slug ?? null,
+    titulo,
+    descricao,
+    endereco: address,
+    celular,
+    email,
+    sala: extractRoom(address || undefined),
+    logo: company.logo?.trim() || null,
+    createdAt: null,
+    updatedAt: null
+  };
+}
+
+function normalizeSearch(value: string | undefined) {
+  return value ? value.trim().toLowerCase() : '';
+}
+
+function matchesSearch(company: FallbackCompany, term: string) {
+  if (!term) {
+    return true;
+  }
+
+  const haystack = [company.name, company.shortDescription, company.description, company.tagline, company.slug, company.address]
+    .map((value) => value?.toLowerCase() ?? '')
+    .join(' ');
+
+  return haystack.includes(term);
+}
+
+function sanitizePage(value: number | undefined, fallback: number) {
+  const parsed = typeof value === 'number' ? Number(value) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+}
+
+function sanitizePageSize(value: number | undefined, fallback: number) {
+  const parsed = typeof value === 'number' ? Number(value) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+
+  return Math.min(50, Math.floor(parsed));
+}
+
+async function getFallbackCategories(): Promise<CategorySummary[]> {
+  try {
+    const data = await loadFallbackData();
+    return (data.categories ?? [])
+      .map((category) => toCategorySummary(category))
+      .filter((category): category is CategorySummary => Boolean(category));
+  } catch (error) {
+    console.error('Falha ao carregar categorias de fallback', error);
+    return [];
+  }
+}
+
+async function getFallbackCompanies(params: CompanyListParams): Promise<CompanyListResponse> {
+  const data = await loadFallbackData();
+  const slug = String(params.category || '').toLowerCase();
+  const categories = data.categories ?? [];
+  const category = categories.find((item) => String(item.slug || item.id || '').toLowerCase() === slug);
+
+  if (!category) {
+    return {
+      items: [],
+      page: 1,
+      pageSize: sanitizePageSize(params.pageSize, 12),
+      total: 0
+    };
+  }
+
+  const searchTerm = normalizeSearch(params.q);
+  const companies = (category.companies ?? []).filter((company) => matchesSearch(company, searchTerm));
+
+  const page = sanitizePage(params.page, 1);
+  const pageSize = sanitizePageSize(params.pageSize, 12);
+  const start = (page - 1) * pageSize;
+  const paginated = companies.slice(start, start + pageSize).map((company) => toCompanyRecord(company));
+
+  return {
+    items: paginated,
+    page,
+    pageSize,
+    total: companies.length
+  };
+}
+
+async function getFallbackCompanyDetail({ category, id }: { category: string; id: string | number }): Promise<CompanyRecord> {
+  const data = await loadFallbackData();
+  const slug = String(category || '').toLowerCase();
+  const categories = data.categories ?? [];
+  const selectedCategory = categories.find((item) => String(item.slug || item.id || '').toLowerCase() === slug);
+
+  if (!selectedCategory) {
+    throw new Error('Categoria não encontrada no fallback');
+  }
+
+  const identifier = String(id).toLowerCase();
+  const company = (selectedCategory.companies ?? []).find((item) => {
+    const companyId = String(item.id ?? item.slug ?? '').toLowerCase();
+    return companyId === identifier;
+  });
+
+  if (!company) {
+    throw new Error('Empresa não encontrada no fallback');
+  }
+
+  return toCompanyRecord(company);
+}
+
 export async function getCategories(): Promise<CategorySummary[]> {
-  const { data } = await client.get<CategorySummary[]>('/categories');
-  return data;
+  try {
+    const { data } = await client.get<CategorySummary[]>('/categories');
+    return data;
+  } catch (error) {
+    console.warn('Falha ao carregar categorias da API, usando fallback.', error);
+    return getFallbackCategories();
+  }
 }
 
 export async function getCompanies({ category, page, pageSize, q }: CompanyListParams): Promise<CompanyListResponse> {
@@ -55,11 +263,21 @@ export async function getCompanies({ category, page, pageSize, q }: CompanyListP
     params.q = q.trim();
   }
 
-  const { data } = await client.get<CompanyListResponse>('/companies', { params });
-  return data;
+  try {
+    const { data } = await client.get<CompanyListResponse>('/companies', { params });
+    return data;
+  } catch (error) {
+    console.warn('Falha ao carregar empresas da API, usando fallback.', error);
+    return getFallbackCompanies({ category, page, pageSize, q });
+  }
 }
 
 export async function getCompany({ category, id }: { category: string; id: string | number }): Promise<CompanyRecord> {
-  const { data } = await client.get<CompanyRecord>(`/companies/${category}/${id}`);
-  return data;
+  try {
+    const { data } = await client.get<CompanyRecord>(`/companies/${category}/${id}`);
+    return data;
+  } catch (error) {
+    console.warn('Falha ao carregar detalhes da empresa na API, usando fallback.', error);
+    return getFallbackCompanyDetail({ category, id });
+  }
 }


### PR DESCRIPTION
## Summary
- add a fallback loader that reads the bundled categories data when API requests fail
- map fallback categories and companies into the existing frontend models with search and pagination support
- ensure company detail views can fall back to the bundled data when the API is unavailable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3bf4d41788330ad35a1d6dcf3b53c