### PR TITLE
Handle missing category tables in countByCategory

### DIFF
--- a/backend/src/services/companies-service.js
+++ b/backend/src/services/companies-service.js
@@ -103,9 +103,18 @@ export async function countByCategory() {
 
   const results = await Promise.all(
     entries.map(async ([slug, table]) => {
-      const rows = await query(`SELECT COUNT(*) AS total FROM \`${table}\``);
-      const total = Number(rows?.[0]?.total ?? 0);
-      return { categoria: slug, total };
+      try {
+        const rows = await query(`SELECT COUNT(*) AS total FROM \`${table}\``);
+        const total = Number(rows?.[0]?.total ?? 0);
+        return { categoria: slug, total };
+      } catch (error) {
+        if (error?.code === 'ER_NO_SUCH_TABLE') {
+          console.warn(`Table "${table}" for category "${slug}" was not found. Returning zero results.`);
+          return { categoria: slug, total: 0 };
+        }
+
+        throw error;
+      }
     })
   );
 


### PR DESCRIPTION
## Summary
- handle missing category tables when computing category counts by returning zero results instead of failing
- log a warning when a category table is absent so the API response still succeeds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3f818afcc8330bc3e356c3f7f5f44