### PR TITLE
Add SQL-backed category endpoints and media proxy

### DIFF
--- a/backend/db/categories.js
+++ b/backend/db/categories.js
@@ -1,0 +1,207 @@
+import pool from './pool.js';
+
+export const CATEGORIES = [
+  { slug: 'administracao', tabela: 'administracao', nome: 'Administração' },
+  { slug: 'advocacia', tabela: 'advocacia', nome: 'Advocacia' },
+  { slug: 'beleza', tabela: 'beleza', nome: 'Beleza' },
+  { slug: 'contabilidade', tabela: 'contabilidade', nome: 'Contabilidade' },
+  { slug: 'imobiliaria', tabela: 'imobiliaria', nome: 'Imobiliária' },
+  { slug: 'industrias', tabela: 'industrias', nome: 'Indústrias' },
+  { slug: 'lojas', tabela: 'lojas', nome: 'Lojas' },
+  { slug: 'saude', tabela: 'saude', nome: 'Saúde' },
+  { slug: 'servicos_publicos', tabela: 'servicos_publicos', nome: 'Serviços Públicos' }
+];
+
+const categoriesBySlug = new Map(CATEGORIES.map((category) => [category.slug, category]));
+
+function normalizeEndereco(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed === 'object') {
+        const formatted = typeof parsed.formatted === 'string' ? parsed.formatted.trim() : null;
+        if (formatted) {
+          return { formatted };
+        }
+      }
+    } catch (error) {
+      // ignore JSON parse errors – fallback to plain text
+    }
+
+    return trimmed;
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const formatted = typeof value.formatted === 'string' ? value.formatted.trim() : null;
+    if (formatted) {
+      return { formatted };
+    }
+  }
+
+  return String(value);
+}
+
+function toNullableString(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const stringValue = String(value).trim();
+  return stringValue.length > 0 ? stringValue : null;
+}
+
+function mapCompanyRow(row = {}) {
+  const endereco = normalizeEndereco(row.endereco);
+  const company = {
+    pk: row.pk != null ? Number(row.pk) : null,
+    id: toNullableString(row.id),
+    titulo: toNullableString(row.titulo),
+    descricao: toNullableString(row.descricao),
+    endereco,
+    celular: toNullableString(row.celular),
+    email: toNullableString(row.email),
+    sala: toNullableString(row.sala),
+    logo: toNullableString(row.logo)
+  };
+
+  if (row.galeria !== undefined && row.galeria !== null) {
+    company.galeria = String(row.galeria);
+  }
+
+  if (row.midia !== undefined && row.midia !== null) {
+    company.midia = String(row.midia);
+  }
+
+  return company;
+}
+
+export function getCategoryBySlug(slug) {
+  if (!slug) {
+    return null;
+  }
+
+  const normalized = String(slug).toLowerCase();
+  return categoriesBySlug.get(normalized) ?? null;
+}
+
+export async function listCategories() {
+  const results = await Promise.all(
+    CATEGORIES.map(async ({ slug, tabela, nome }) => {
+      try {
+        const [rows] = await pool.query(`SELECT COUNT(*) AS total FROM \`${tabela}\``);
+        const count = Number(rows?.[0]?.total ?? 0);
+        return { slug, nome, count };
+      } catch (error) {
+        if (error?.code === 'ER_NO_SUCH_TABLE') {
+          return { slug, nome, count: 0 };
+        }
+
+        throw error;
+      }
+    })
+  );
+
+  return results;
+}
+
+function sanitizePage(value, fallback) {
+  const number = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(number) || number < 1) {
+    return fallback;
+  }
+
+  return number;
+}
+
+function sanitizePageSize(value, fallback) {
+  const number = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(number) || number < 1) {
+    return fallback;
+  }
+
+  return Math.min(number, 50);
+}
+
+export async function listCompanies(tabela, { page = 1, pageSize = 12, q = '' } = {}) {
+  const currentPage = sanitizePage(page, 1);
+  const currentPageSize = sanitizePageSize(pageSize, 12);
+  const offset = (currentPage - 1) * currentPageSize;
+  const searchTerm = typeof q === 'string' ? q.trim() : '';
+
+  const filters = [];
+  const params = [];
+
+  if (searchTerm) {
+    const like = `%${searchTerm}%`;
+    filters.push(
+      "(" +
+        "COALESCE(titulo, '') LIKE ? OR " +
+        "COALESCE(descricao, '') LIKE ? OR " +
+        "COALESCE(email, '') LIKE ?" +
+      ")"
+    );
+    params.push(like, like, like);
+  }
+
+  const whereClause = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
+
+  const selectColumns = [
+    "COALESCE(pk, 0) AS pk",
+    "COALESCE(id, '') AS id",
+    "COALESCE(titulo, '') AS titulo",
+    "COALESCE(descricao, '') AS descricao",
+    "COALESCE(endereco, '') AS endereco",
+    "COALESCE(celular, '') AS celular",
+    "COALESCE(email, '') AS email",
+    "COALESCE(sala, '') AS sala",
+    "COALESCE(logo, '') AS logo"
+  ];
+
+  const querySql =
+    `SELECT ${selectColumns.join(', ')} FROM \`${tabela}\` ${whereClause} ORDER BY titulo ASC LIMIT ? OFFSET ?`;
+  const countSql = `SELECT COUNT(*) AS total FROM \`${tabela}\` ${whereClause}`;
+
+  const [rows] = await pool.query(querySql, [...params, currentPageSize, offset]);
+  const [countRows] = await pool.query(countSql, params);
+  const total = Number(countRows?.[0]?.total ?? 0);
+
+  return {
+    page: currentPage,
+    pageSize: currentPageSize,
+    total,
+    items: rows.map((row) => mapCompanyRow(row))
+  };
+}
+
+export async function getCompany(tabela, id) {
+  if (!id) {
+    return null;
+  }
+
+  const identifier = String(id).trim();
+  if (!identifier) {
+    return null;
+  }
+
+  const [rows] = await pool.query(
+    `SELECT * FROM \`${tabela}\` WHERE id = ? OR pk = ? LIMIT 1`,
+    [identifier, identifier]
+  );
+
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return null;
+  }
+
+  return mapCompanyRow(rows[0]);
+}
+

--- a/backend/src/middleware/error-handler.js
+++ b/backend/src/middleware/error-handler.js
@@ -13,6 +13,7 @@ export function errorHandler(err, req, res, next) {
 
   const status = err.status || err.statusCode || 500;
   const message = err.message || 'Erro interno inesperado';
+  const code = err.code || 'INTERNAL_ERROR';
 
   if (status >= 500) {
     // eslint-disable-next-line no-console
@@ -20,7 +21,7 @@ export function errorHandler(err, req, res, next) {
   }
 
   res.status(status).json({
-    error: err.code || 'InternalError',
-    message
+    error: message,
+    code
   });
 }

--- a/backend/src/rotas/companies.js
+++ b/backend/src/rotas/companies.js
@@ -1,0 +1,75 @@
+import { Router } from 'express';
+import {
+  CATEGORIES,
+  getCategoryBySlug,
+  getCompany,
+  listCategories,
+  listCompanies
+} from '../../db/categories.js';
+
+const router = Router();
+
+function sendError(res, status, code, message) {
+  return res.status(status).json({ error: message, code });
+}
+
+router.get('/categories', async (_req, res) => {
+  try {
+    const categories = await listCategories();
+    return res.json(categories);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to list categories', error);
+    return sendError(res, 500, 'CATEGORIES_FETCH_FAILED', 'Falha ao carregar categorias');
+  }
+});
+
+router.get('/companies', async (req, res) => {
+  const { categoria, page = '1', pageSize = '12', q = '' } = req.query;
+  const category = getCategoryBySlug(categoria);
+
+  if (!category) {
+    return sendError(res, 404, 'CATEGORY_NOT_FOUND', 'Categoria não encontrada');
+  }
+
+  try {
+    const result = await listCompanies(category.tabela, {
+      page,
+      pageSize,
+      q
+    });
+
+    return res.json(result);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to list companies', error);
+    return sendError(res, 500, 'COMPANIES_FETCH_FAILED', 'Falha ao carregar empresas');
+  }
+});
+
+router.get('/companies/:categoria/:id', async (req, res) => {
+  const { categoria, id } = req.params;
+  const category = getCategoryBySlug(categoria);
+
+  if (!category) {
+    return sendError(res, 404, 'CATEGORY_NOT_FOUND', 'Categoria não encontrada');
+  }
+
+  try {
+    const company = await getCompany(category.tabela, id);
+
+    if (!company) {
+      return sendError(res, 404, 'COMPANY_NOT_FOUND', 'Empresa não encontrada');
+    }
+
+    return res.json(company);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to load company', error);
+    return sendError(res, 500, 'COMPANY_FETCH_FAILED', 'Falha ao carregar empresa');
+  }
+});
+
+export { CATEGORIES };
+export default router;
+

--- a/backend/src/rotas/health.js
+++ b/backend/src/rotas/health.js
@@ -1,0 +1,46 @@
+import { Router } from 'express';
+import { CATEGORIES } from './companies.js';
+import pool, { ping } from '../../db/pool.js';
+
+const router = Router();
+
+router.get('/health', (req, res) => {
+  res.json({
+    status: 'ok',
+    uptime: process.uptime(),
+    env: {
+      USE_JSON_DB: process.env.USE_JSON_DB ?? null,
+      NODE_ENV: process.env.NODE_ENV ?? null
+    }
+  });
+});
+
+router.get('/health/db', async (_req, res) => {
+  try {
+    const dbOk = await ping();
+    const tablesEntries = await Promise.all(
+      CATEGORIES.map(async ({ slug, tabela }) => {
+        try {
+          const [rows] = await pool.query('SHOW TABLES LIKE ?', [tabela]);
+          return [slug, Array.isArray(rows) && rows.length > 0];
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error(`Failed to inspect table ${tabela}`, error);
+          return [slug, false];
+        }
+      })
+    );
+
+    const tables = Object.fromEntries(tablesEntries);
+    const ok = dbOk && Object.values(tables).every(Boolean);
+
+    return res.json({ ok, tables });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Database health check failed', error);
+    return res.status(500).json({ error: 'Falha ao verificar banco', code: 'DB_HEALTHCHECK_FAILED' });
+  }
+});
+
+export default router;
+

--- a/backend/src/rotas/media.js
+++ b/backend/src/rotas/media.js
@@ -1,0 +1,104 @@
+import { Router } from 'express';
+import axios from 'axios';
+import { isIP } from 'net';
+import { pipeline } from 'stream';
+import { promisify } from 'util';
+
+const router = Router();
+const streamPipeline = promisify(pipeline);
+
+function isPrivateHostname(hostname) {
+  if (!hostname) {
+    return true;
+  }
+
+  const lowerHost = hostname.toLowerCase();
+  if (lowerHost === 'localhost' || lowerHost === '127.0.0.1') {
+    return true;
+  }
+
+  const ipVersion = isIP(lowerHost);
+  if (ipVersion) {
+    const parts = lowerHost.split('.').map((segment) => Number.parseInt(segment, 10));
+    if (ipVersion === 4) {
+      if (parts[0] === 10) {
+        return true;
+      }
+      if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) {
+        return true;
+      }
+      if (parts[0] === 192 && parts[1] === 168) {
+        return true;
+      }
+      if (parts[0] === 127) {
+        return true;
+      }
+    }
+
+    if (ipVersion === 6) {
+      if (lowerHost === '::1') {
+        return true;
+      }
+
+      if (lowerHost.startsWith('fd') || lowerHost.startsWith('fe80')) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+router.get('/media', async (req, res) => {
+  const { url } = req.query;
+
+  if (typeof url !== 'string' || url.trim().length === 0) {
+    return res.status(400).json({ error: 'Parâmetro "url" é obrigatório', code: 'INVALID_URL' });
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch (error) {
+    return res.status(400).json({ error: 'URL inválida', code: 'INVALID_URL' });
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return res.status(400).json({ error: 'Apenas URLs HTTPS são permitidas', code: 'INVALID_URL_PROTOCOL' });
+  }
+
+  if (isPrivateHostname(parsed.hostname)) {
+    return res.status(400).json({ error: 'Domínio não permitido', code: 'INVALID_URL_DOMAIN' });
+  }
+
+  try {
+    const response = await axios.get(parsed.toString(), {
+      responseType: 'stream',
+      timeout: 15000,
+      headers: {
+        'User-Agent': 'Jaguar-Center-Plaza/1.0'
+      },
+      validateStatus: (status) => status >= 200 && status < 300
+    });
+
+    res.setHeader('Cache-Control', 'public, max-age=86400');
+
+    if (response.headers['content-type']) {
+      res.setHeader('Content-Type', response.headers['content-type']);
+    }
+
+    if (response.headers['content-length']) {
+      res.setHeader('Content-Length', response.headers['content-length']);
+    }
+
+    res.status(response.status);
+    await streamPipeline(response.data, res);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to proxy media', error?.message || error);
+    res.status(404).json({ error: 'Mídia não encontrada', code: 'MEDIA_NOT_FOUND' });
+  }
+});
+
+export default router;
+

--- a/backend/src/routes/companies.js
+++ b/backend/src/routes/companies.js
@@ -12,8 +12,11 @@ function isValidCategory(slug) {
 }
 
 router.get('/companies', async (req, res) => {
-  const { category, page = '1', pageSize = '12', q = '' } = req.query;
-  const normalizedCategory = typeof category === 'string' ? category.toLowerCase() : '';
+  const { category, categoria, page = '1', pageSize = '12', q = '' } = req.query;
+  const sourceCategory = typeof categoria === 'string' && categoria
+    ? categoria
+    : category;
+  const normalizedCategory = typeof sourceCategory === 'string' ? sourceCategory.toLowerCase() : '';
 
   if (!normalizedCategory) {
     return res.status(400).json({ error: 'category is required' });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -6,7 +6,9 @@ import cors from 'cors';
 import express from 'express';
 import helmet from 'helmet';
 
-import companiesRouter from './routes/companies.js';
+import companiesRouter from './rotas/companies.js';
+import healthRouter from './rotas/health.js';
+import mediaRouter from './rotas/media.js';
 import { env, resolvePublicBaseUrl } from './config/env.js';
 import { errorHandler } from './middleware/error-handler.js';
 import apiRouter from './routes/index.js';
@@ -24,13 +26,14 @@ export function createApp() {
     app.set('trust proxy', 1);
   }
 
-  app.use(helmet());
   app.use(
-    helmet.contentSecurityPolicy({
-      useDefaults: true,
-      directives: {
-        'img-src': ["'self'", 'data:', 'https:', '*.wixstatic.com', 'static.wixstatic.com'],
-        'connect-src': ["'self'", 'https:']
+    helmet({
+      contentSecurityPolicy: {
+        useDefaults: false,
+        directives: {
+          defaultSrc: ["'self'"],
+          imgSrc: ["'self'", 'data:', 'blob:']
+        }
       }
     })
   );
@@ -52,8 +55,10 @@ export function createApp() {
     }
   });
 
-  app.use('/api', apiRouter);
+  app.use('/api', healthRouter);
+  app.use('/api', mediaRouter);
   app.use('/api', companiesRouter);
+  app.use('/api', apiRouter);
 
   if (fs.existsSync(publicDir)) {
     app.use(express.static(publicDir, { index: false, maxAge: env.nodeEnv === 'production' ? '1h' : 0 }));

--- a/backend/test/companies.test.js
+++ b/backend/test/companies.test.js
@@ -24,14 +24,14 @@ async function ensureDatabaseAvailable() {
   }
 }
 
-test('GET /api/companies?category=administracao retorna lista', async (t) => {
+test('GET /api/companies?categoria=administracao retorna lista', async (t) => {
   const available = await ensureDatabaseAvailable();
   if (!available) {
     t.skip('Banco de dados indisponível no ambiente de testes.');
     return;
   }
 
-  const response = await request(app).get('/api/companies').query({ category: DEFAULT_CATEGORY });
+  const response = await request(app).get('/api/companies').query({ categoria: DEFAULT_CATEGORY });
 
   if (response.status === 500) {
     t.skip('Serviço de empresas indisponível para testes.');
@@ -48,7 +48,7 @@ test('GET /api/companies/administracao/:id retorna detalhe', async (t) => {
     return;
   }
 
-  const listResponse = await request(app).get('/api/companies').query({ category: DEFAULT_CATEGORY });
+  const listResponse = await request(app).get('/api/companies').query({ categoria: DEFAULT_CATEGORY });
   if (listResponse.status !== 200 || !Array.isArray(listResponse.body.items) || listResponse.body.items.length === 0) {
     t.skip('Nenhuma empresa disponível para testar detalhes.');
   }


### PR DESCRIPTION
## Summary
- connect to MariaDB using a mysql2 pool and shared category helpers
- expose new /api categories, companies, and health endpoints backed by SQL
- add an HTTPS media proxy and tighten CSP to rely on proxied images

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3fd7acdc883308da8841fd8a0aa5e