### PR TITLE
Use MariaDB-backed company endpoints and remove JSON fallbacks

### DIFF
--- a/backend/src/rotas/companies.js
+++ b/backend/src/rotas/companies.js
@@ -1,11 +1,5 @@
 import { Router } from 'express';
-import {
-  CATEGORIES,
-  getCategoryBySlug,
-  getCompany,
-  listCategories,
-  listCompanies
-} from '../../db/categories.js';
+import { CATEGORIES, getCategoryBySlug, getCompany, listCompanies } from '../../db/categories.js';
 
 const router = Router();
 
@@ -13,20 +7,10 @@ function sendError(res, status, code, message) {
   return res.status(status).json({ error: message, code });
 }
 
-router.get('/categories', async (_req, res) => {
-  try {
-    const categories = await listCategories();
-    return res.json(categories);
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error('Failed to list categories', error);
-    return sendError(res, 500, 'CATEGORIES_FETCH_FAILED', 'Falha ao carregar categorias');
-  }
-});
-
 router.get('/companies', async (req, res) => {
-  const { categoria, page = '1', pageSize = '12', q = '' } = req.query;
-  const category = getCategoryBySlug(categoria);
+  const { category: categoryParam, categoria, page = '1', pageSize = '12', q = '' } = req.query;
+  const slug = categoryParam || categoria;
+  const category = getCategoryBySlug(slug);
 
   if (!category) {
     return sendError(res, 404, 'CATEGORY_NOT_FOUND', 'Categoria não encontrada');
@@ -47,9 +31,9 @@ router.get('/companies', async (req, res) => {
   }
 });
 
-router.get('/companies/:categoria/:id', async (req, res) => {
-  const { categoria, id } = req.params;
-  const category = getCategoryBySlug(categoria);
+router.get('/companies/:category/:id', async (req, res) => {
+  const { category: categorySlug, id } = req.params;
+  const category = getCategoryBySlug(categorySlug);
 
   if (!category) {
     return sendError(res, 404, 'CATEGORY_NOT_FOUND', 'Categoria não encontrada');

--- a/frontend/src/api/companies.ts
+++ b/frontend/src/api/companies.ts
@@ -5,33 +5,6 @@ const client = axios.create({
   baseURL: baseUrl || '/api'
 });
 
-const FALLBACK_PATH = '/assets/categories-fallback.json';
-
-type FallbackCompany = {
-  id?: string | number;
-  slug?: string;
-  name?: string;
-  tagline?: string;
-  shortDescription?: string;
-  description?: string;
-  phones?: string[];
-  emails?: string[];
-  whatsapp?: string;
-  address?: string;
-  logo?: string;
-};
-
-type FallbackCategory = {
-  id?: string;
-  slug?: string;
-  name?: string;
-  companies?: FallbackCompany[];
-};
-
-type FallbackResponse = {
-  categories?: FallbackCategory[];
-};
-
 export type CategorySummary = {
   slug: string;
   label: string;
@@ -46,7 +19,8 @@ export type CompanyListParams = {
 };
 
 export type CompanyRecord = {
-  id: string | number | null;
+  pk: number | null;
+  id: string | null;
   titulo: string | null;
   descricao: string | null;
   endereco: string | null;
@@ -54,6 +28,8 @@ export type CompanyRecord = {
   email: string | null;
   sala: string | null;
   logo: string | null;
+  galeria: string[];
+  midia: string[];
   createdAt: string | null;
   updatedAt: string | null;
 };
@@ -65,219 +41,109 @@ export type CompanyListResponse = {
   total: number;
 };
 
-let fallbackDataPromise: Promise<FallbackResponse> | null = null;
+type CompanyRecordApi = Partial<Omit<CompanyRecord, 'galeria' | 'midia'>> & {
+  galeria?: string[] | null;
+  midia?: string[] | null;
+};
 
-async function loadFallbackData(): Promise<FallbackResponse> {
-  if (!fallbackDataPromise) {
-    fallbackDataPromise = fetch(FALLBACK_PATH, { cache: 'no-store' })
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`Falha ao carregar fallback ${FALLBACK_PATH}`);
-        }
-        return response.json() as Promise<FallbackResponse>;
-      })
-      .catch((error) => {
-        fallbackDataPromise = null;
-        throw error;
-      });
-  }
+type CompanyListResponseApi = {
+  items: CompanyRecordApi[];
+  page: number;
+  pageSize: number;
+  total: number;
+};
 
-  return fallbackDataPromise;
-}
-
-function labelFromSlug(slug: string) {
-  return slug
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (letter) => letter.toUpperCase());
-}
-
-function toCategorySummary(category: FallbackCategory): CategorySummary | null {
-  const slug = String(category.slug || category.id || '').trim();
-  if (!slug) {
+function toNullableString(value: unknown): string | null {
+  if (value === null || value === undefined) {
     return null;
   }
 
-  const label = category.name?.trim() || labelFromSlug(slug);
-  const total = category.companies?.length ?? 0;
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
 
-  return { slug, label, total };
-}
+  if (typeof value !== 'string') {
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? String(value) : null;
+    }
 
-function extractRoom(address: string | undefined): string | null {
-  if (!address) {
     return null;
   }
 
-  const match = address.match(/sala\s+([\wº]+)/i);
-  if (!match) {
-    return null;
-  }
-
-  return match[1] ? match[1].toUpperCase() : match[0];
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
-function toCompanyRecord(company: FallbackCompany): CompanyRecord {
-  const titulo = company.name?.trim() || company.slug?.trim() || null;
-  const descriptions = [company.shortDescription, company.description, company.tagline]
-    .map((item) => (item?.trim() ? item.trim() : ''))
-    .filter((item) => item.length > 0);
-  const descricao = descriptions[0] ?? null;
-  const address = company.address?.trim() || null;
-  const phones = Array.isArray(company.phones) ? company.phones : [];
-  const emails = Array.isArray(company.emails) ? company.emails : [];
-  const celular = phones.find((phone) => phone && phone.trim())?.trim() || company.whatsapp?.trim() || null;
-  const email = emails.find((value) => value && value.trim())?.trim() || null;
-
-  return {
-    id: company.id ?? company.slug ?? null,
-    titulo,
-    descricao,
-    endereco: address,
-    celular,
-    email,
-    sala: extractRoom(address || undefined),
-    logo: company.logo?.trim() || null,
-    createdAt: null,
-    updatedAt: null
-  };
-}
-
-function normalizeSearch(value: string | undefined) {
-  return value ? value.trim().toLowerCase() : '';
-}
-
-function matchesSearch(company: FallbackCompany, term: string) {
-  if (!term) {
-    return true;
-  }
-
-  const haystack = [company.name, company.shortDescription, company.description, company.tagline, company.slug, company.address]
-    .map((value) => value?.toLowerCase() ?? '')
-    .join(' ');
-
-  return haystack.includes(term);
-}
-
-function sanitizePage(value: number | undefined, fallback: number) {
-  const parsed = typeof value === 'number' ? Number(value) : Number.NaN;
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    return fallback;
-  }
-  return Math.floor(parsed);
-}
-
-function sanitizePageSize(value: number | undefined, fallback: number) {
-  const parsed = typeof value === 'number' ? Number(value) : Number.NaN;
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    return fallback;
-  }
-
-  return Math.min(50, Math.floor(parsed));
-}
-
-async function getFallbackCategories(): Promise<CategorySummary[]> {
-  try {
-    const data = await loadFallbackData();
-    return (data.categories ?? [])
-      .map((category) => toCategorySummary(category))
-      .filter((category): category is CategorySummary => Boolean(category));
-  } catch (error) {
-    console.error('Falha ao carregar categorias de fallback', error);
+function normalizeStringArray(values?: string[] | null): string[] {
+  if (!Array.isArray(values)) {
     return [];
   }
+
+  return values
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter((item) => item.length > 0);
 }
 
-async function getFallbackCompanies(params: CompanyListParams): Promise<CompanyListResponse> {
-  const data = await loadFallbackData();
-  const slug = String(params.category || '').toLowerCase();
-  const categories = data.categories ?? [];
-  const category = categories.find((item) => String(item.slug || item.id || '').toLowerCase() === slug);
-
-  if (!category) {
-    return {
-      items: [],
-      page: 1,
-      pageSize: sanitizePageSize(params.pageSize, 12),
-      total: 0
-    };
-  }
-
-  const searchTerm = normalizeSearch(params.q);
-  const companies = (category.companies ?? []).filter((company) => matchesSearch(company, searchTerm));
-
-  const page = sanitizePage(params.page, 1);
-  const pageSize = sanitizePageSize(params.pageSize, 12);
-  const start = (page - 1) * pageSize;
-  const paginated = companies.slice(start, start + pageSize).map((company) => toCompanyRecord(company));
-
+function normalizeCompanyRecord(record: CompanyRecordApi): CompanyRecord {
   return {
-    items: paginated,
-    page,
-    pageSize,
-    total: companies.length
+    pk:
+      typeof record.pk === 'number'
+        ? Number.isFinite(record.pk)
+          ? record.pk
+          : null
+        : typeof record.pk === 'string' && record.pk.trim().length > 0 && !Number.isNaN(Number(record.pk))
+          ? Number(record.pk)
+          : null,
+    id: toNullableString(record.id),
+    titulo: toNullableString(record.titulo),
+    descricao: toNullableString(record.descricao),
+    endereco: toNullableString(record.endereco),
+    celular: toNullableString(record.celular),
+    email: toNullableString(record.email),
+    sala: toNullableString(record.sala),
+    logo: toNullableString(record.logo),
+    galeria: normalizeStringArray(record.galeria),
+    midia: normalizeStringArray(record.midia),
+    createdAt: toNullableString(record.createdAt ?? null),
+    updatedAt: toNullableString(record.updatedAt ?? null)
   };
-}
-
-async function getFallbackCompanyDetail({ category, id }: { category: string; id: string | number }): Promise<CompanyRecord> {
-  const data = await loadFallbackData();
-  const slug = String(category || '').toLowerCase();
-  const categories = data.categories ?? [];
-  const selectedCategory = categories.find((item) => String(item.slug || item.id || '').toLowerCase() === slug);
-
-  if (!selectedCategory) {
-    throw new Error('Categoria não encontrada no fallback');
-  }
-
-  const identifier = String(id).toLowerCase();
-  const company = (selectedCategory.companies ?? []).find((item) => {
-    const companyId = String(item.id ?? item.slug ?? '').toLowerCase();
-    return companyId === identifier;
-  });
-
-  if (!company) {
-    throw new Error('Empresa não encontrada no fallback');
-  }
-
-  return toCompanyRecord(company);
 }
 
 export async function getCategories(): Promise<CategorySummary[]> {
-  try {
-    const { data } = await client.get<CategorySummary[]>('/categories');
-    return data;
-  } catch (error) {
-    console.warn('Falha ao carregar categorias da API, usando fallback.', error);
-    return getFallbackCategories();
-  }
+  const { data } = await client.get<CategorySummary[]>('/categories');
+  return data.map((category) => ({
+    slug: category.slug,
+    label: category.label,
+    total: category.total
+  }));
 }
 
 export async function getCompanies({ category, page, pageSize, q }: CompanyListParams): Promise<CompanyListResponse> {
   const params: Record<string, string | number> = { category };
+
   if (typeof page === 'number') {
     params.page = page;
   }
+
   if (typeof pageSize === 'number') {
     params.pageSize = pageSize;
   }
+
   if (q && q.trim()) {
     params.q = q.trim();
   }
 
-  try {
-    const { data } = await client.get<CompanyListResponse>('/companies', { params });
-    return data;
-  } catch (error) {
-    console.warn('Falha ao carregar empresas da API, usando fallback.', error);
-    return getFallbackCompanies({ category, page, pageSize, q });
-  }
+  const { data } = await client.get<CompanyListResponseApi>('/companies', { params });
+
+  return {
+    items: data.items.map((item) => normalizeCompanyRecord(item)),
+    page: data.page,
+    pageSize: data.pageSize,
+    total: data.total
+  };
 }
 
 export async function getCompany({ category, id }: { category: string; id: string | number }): Promise<CompanyRecord> {
-  try {
-    const { data } = await client.get<CompanyRecord>(`/companies/${category}/${id}`);
-    return data;
-  } catch (error) {
-    console.warn('Falha ao carregar detalhes da empresa na API, usando fallback.', error);
-    return getFallbackCompanyDetail({ category, id });
-  }
+  const { data } = await client.get<CompanyRecordApi>(`/companies/${category}/${id}`);
+  return normalizeCompanyRecord(data);
 }

--- a/frontend/src/pages/CompanyCategory.tsx
+++ b/frontend/src/pages/CompanyCategory.tsx
@@ -193,50 +193,58 @@ export default function CompanyCategoryPage() {
           {category && items.length > 0 && (
             <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
               {items.map((company: CompanyRecord, index) => {
-                const key = company.id ?? `${index}-${company.titulo ?? 'empresa'}`;
+                const identifier = company.id ?? (company.pk != null ? String(company.pk) : null);
+                const key = identifier ?? `${index}-${company.titulo ?? 'empresa'}`;
+                const detailPath = identifier ? `/empresas/${category.slug}/${identifier}` : null;
                 return (
                   <article key={key} className="flex h-full flex-col overflow-hidden rounded-3xl bg-white shadow-lg">
-                  {company.logo && (
-                    <div className="flex items-center justify-center bg-primary-50 p-6">
-                      <img src={company.logo} alt={company.titulo ?? 'Empresa'} className="max-h-20 object-contain" />
+                    {company.logo && (
+                      <div className="flex items-center justify-center bg-primary-50 p-6">
+                        <img src={company.logo} alt={company.titulo ?? 'Empresa'} className="max-h-20 object-contain" />
+                      </div>
+                    )}
+                    <div className="flex flex-1 flex-col gap-4 p-6">
+                      <div className="space-y-2">
+                        <h3 className="text-xl font-semibold text-primary-800">{company.titulo || 'Empresa sem título'}</h3>
+                        {company.descricao && <p className="text-sm text-[#4f5d55]">{company.descricao}</p>}
+                      </div>
+                      <div className="space-y-2 text-sm text-[#4f5d55]">
+                        {company.endereco && (
+                          <p>
+                            <span className="font-semibold text-primary-700">Endereço:</span> {company.endereco}
+                          </p>
+                        )}
+                        {company.sala && (
+                          <p>
+                            <span className="font-semibold text-primary-700">Sala:</span> {company.sala}
+                          </p>
+                        )}
+                        {company.celular && (
+                          <p>
+                            <span className="font-semibold text-primary-700">Telefone:</span> {company.celular}
+                          </p>
+                        )}
+                        {company.email && (
+                          <p>
+                            <span className="font-semibold text-primary-700">E-mail:</span> {company.email}
+                          </p>
+                        )}
+                      </div>
+                      <div className="mt-auto">
+                        {detailPath ? (
+                          <Link
+                            to={detailPath}
+                            className="inline-flex items-center rounded-full bg-primary-700 px-5 py-2 text-sm font-semibold text-white transition hover:bg-primary-600"
+                          >
+                            Ver detalhes
+                          </Link>
+                        ) : (
+                          <span className="inline-flex cursor-not-allowed items-center rounded-full bg-primary-200 px-5 py-2 text-sm font-semibold text-white">
+                            Detalhes indisponíveis
+                          </span>
+                        )}
+                      </div>
                     </div>
-                  )}
-                  <div className="flex flex-1 flex-col gap-4 p-6">
-                    <div className="space-y-2">
-                      <h3 className="text-xl font-semibold text-primary-800">{company.titulo || 'Empresa sem título'}</h3>
-                      {company.descricao && <p className="text-sm text-[#4f5d55]">{company.descricao}</p>}
-                    </div>
-                    <div className="space-y-2 text-sm text-[#4f5d55]">
-                      {company.endereco && (
-                        <p>
-                          <span className="font-semibold text-primary-700">Endereço:</span> {company.endereco}
-                        </p>
-                      )}
-                      {company.sala && (
-                        <p>
-                          <span className="font-semibold text-primary-700">Sala:</span> {company.sala}
-                        </p>
-                      )}
-                      {company.celular && (
-                        <p>
-                          <span className="font-semibold text-primary-700">Telefone:</span> {company.celular}
-                        </p>
-                      )}
-                      {company.email && (
-                        <p>
-                          <span className="font-semibold text-primary-700">E-mail:</span> {company.email}
-                        </p>
-                      )}
-                    </div>
-                    <div className="mt-auto">
-                      <Link
-                        to={`/empresas/${category.slug}/${company.id}`}
-                        className="inline-flex items-center rounded-full bg-primary-700 px-5 py-2 text-sm font-semibold text-white transition hover:bg-primary-600"
-                      >
-                        Ver detalhes
-                      </Link>
-                    </div>
-                  </div>
                   </article>
                 );
               })}


### PR DESCRIPTION
## Summary
- normalize company queries to only use MariaDB, parse JSON fields, and proxy remote media through `/api/media`
- update the `/api/companies` routes to validate category slugs and expose detail endpoints by table
- drop frontend JSON fallbacks, normalize API responses, and disable company detail links when no identifier is available

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e44b4f77ec83309bb360aaad42b1cf