### PR TITLE
Fix duplicated prioritized keys declaration in categories media normalization

### DIFF
--- a/backend/db/categories.js
+++ b/backend/db/categories.js
@@ -147,8 +147,6 @@ function normalizeMediaList(value) {
 
       const prioritizedKeys = ['url', 'src', 'imagem', 'image', 'foto', 'value'];
 
-      const prioritizedKeys = ['url', 'src', 'imagem', 'image', 'value'];
-
       for (const key of prioritizedKeys) {
         const valueForKey = candidate[key];
         if (typeof valueForKey === 'string' && valueForKey.trim().length > 0) {


### PR DESCRIPTION
## Summary
- remove the duplicated `prioritizedKeys` declaration inside `normalizeMediaList`
- ensure the media normalization keeps all expected keys without throwing a syntax error

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68e45ece09888330885c2244142fad1d