### PR TITLE
Normalize company category slugs for navigation

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { Link, NavLink } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import Container from './Container';
 import { fetchAreas } from '../../lib/api';
+import { isLinkedCategory, normalizeCategorySlug } from '../../lib/categories';
 
 const navItems = [
   { label: 'Home', to: '/', type: 'route' as const },
@@ -14,14 +15,22 @@ const navItems = [
 export default function Header() {
   const query = useQuery({ queryKey: ['areas'], queryFn: fetchAreas });
   const areas = query.data?.items ?? [];
-  const categoryLinks = useMemo(
-    () =>
-      areas.map((item) => ({
-        label: item.name,
-        slug: item.slug || item.id
-      })),
-    [areas]
-  );
+  const categoryLinks = useMemo(() => {
+    return areas
+      .map((item) => {
+        const slug = normalizeCategorySlug(item.slug ?? item.id ?? null);
+
+        if (!slug || !isLinkedCategory(slug)) {
+          return null;
+        }
+
+        return {
+          slug,
+          label: item.name
+        };
+      })
+      .filter((item): item is { slug: string; label: string } => item !== null);
+  }, [areas]);
 
   return (
     <header className="sticky top-0 z-50 shadow-sm">

--- a/frontend/src/lib/categories.ts
+++ b/frontend/src/lib/categories.ts
@@ -1,0 +1,42 @@
+export const LINKED_CATEGORY_SLUGS = [
+  'administracao',
+  'advocacia',
+  'beleza',
+  'contabilidade',
+  'imobiliaria',
+  'industrias',
+  'lojas',
+  'saude',
+  'servicos_publicos'
+] as const;
+
+const LINKED_CATEGORY_SET = new Set<string>(LINKED_CATEGORY_SLUGS);
+
+export function normalizeCategorySlug(value?: string | number | null) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const stringValue = String(value).trim();
+  if (!stringValue) {
+    return '';
+  }
+
+  const withoutDiacritics = stringValue.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  const sanitized = withoutDiacritics
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '');
+
+  return sanitized;
+}
+
+export function isLinkedCategory(slug?: string | number | null) {
+  const normalized = normalizeCategorySlug(slug);
+  if (!normalized) {
+    return false;
+  }
+
+  return LINKED_CATEGORY_SET.has(normalized);
+}


### PR DESCRIPTION
## Summary
- add a helper to normalize API slugs so they match the linked category table names
- update navigation and company listings to use the normalized slug and keep only the allowed categories

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68e45fff0cb8833088a7f66ce291599f