### PR TITLE
Handle dynamic company table schemas

### DIFF
--- a/backend/test/categories-helpers.test.js
+++ b/backend/test/categories-helpers.test.js
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __internal } from '../db/categories.js';
+
+const { buildSearchClause, buildOrderByClause } = __internal;
+
+test('buildSearchClause uses available searchable columns', () => {
+  const columns = new Map([
+    ['titulo', 'titulo'],
+    ['email', 'email']
+  ]);
+
+  const { clause, params } = buildSearchClause(columns, 'teste');
+
+  assert.equal(clause, "(COALESCE(`titulo`, '') LIKE ? OR COALESCE(`email`, '') LIKE ?)");
+  assert.deepEqual(params, ['%teste%', '%teste%']);
+});
+
+test('buildSearchClause returns empty clause when nothing matches', () => {
+  const columns = new Map([
+    ['id', 'id']
+  ]);
+
+  const { clause, params } = buildSearchClause(columns, 'teste');
+
+  assert.equal(clause, '');
+  assert.deepEqual(params, []);
+});
+
+test('buildSearchClause ignores empty search terms', () => {
+  const columns = new Map([
+    ['titulo', 'titulo']
+  ]);
+
+  const { clause, params } = buildSearchClause(columns, '');
+
+  assert.equal(clause, '');
+  assert.deepEqual(params, []);
+});
+
+test('buildOrderByClause prefers textual columns', () => {
+  const columns = new Map([
+    ['nome', 'Nome'],
+    ['id', 'id']
+  ]);
+
+  assert.equal(
+    buildOrderByClause(columns),
+    "ORDER BY (COALESCE(`Nome`, '') = ''), `Nome` ASC"
+  );
+});
+
+test('buildOrderByClause falls back to identifiers', () => {
+  const columns = new Map([
+    ['id', 'id']
+  ]);
+
+  assert.equal(buildOrderByClause(columns), 'ORDER BY `id` ASC');
+});
+
+test('buildOrderByClause returns default ordering when nothing matches', () => {
+  const columns = new Map();
+
+  assert.equal(buildOrderByClause(columns), 'ORDER BY 1');
+});


### PR DESCRIPTION
## Summary
- cache company table column metadata to build safe search/order clauses and avoid querying missing fields
- return empty results instead of 500s when a category table is absent and reuse new helpers
- add unit tests covering the clause builders used by the listing logic

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e4631c5e9083309cbe6722a8d922ed