### PR TITLE
Fix company title mapping for case-variant columns

### DIFF
--- a/backend/db/categories.js
+++ b/backend/db/categories.js
@@ -14,6 +14,107 @@ export const CATEGORIES = [
 
 const categoriesBySlug = new Map(CATEGORIES.map((category) => [category.slug, category]));
 
+const TABLE_COLUMNS_CACHE = new Map();
+
+const SEARCHABLE_COLUMNS = [
+  'titulo',
+  'nome',
+  'name',
+  'razao_social',
+  'descricao',
+  'description',
+  'tagline',
+  'email',
+  'celular',
+  'telefone',
+  'whatsapp'
+];
+
+const TITLE_PREFERRED_COLUMNS = [
+  'titulo',
+  'nome',
+  'name',
+  'razao_social',
+  'descricao',
+  'description',
+  'tagline'
+];
+
+const FALLBACK_ORDER_COLUMNS = ['pk', 'id'];
+
+function normalizeColumnName(column) {
+  return typeof column === 'string' ? column.trim() : '';
+}
+
+async function getTableColumns(table) {
+  if (TABLE_COLUMNS_CACHE.has(table)) {
+    return TABLE_COLUMNS_CACHE.get(table);
+  }
+
+  try {
+    const [rows] = await pool.query(`SHOW COLUMNS FROM \`${table}\``);
+    const entries = Array.isArray(rows)
+      ? rows
+          .map((row) => {
+            const field = normalizeColumnName(row.Field ?? row.field);
+            return field ? [field.toLowerCase(), field] : null;
+          })
+          .filter((entry) => entry !== null)
+      : [];
+
+    const columnsMap = new Map(entries);
+    TABLE_COLUMNS_CACHE.set(table, columnsMap);
+    return columnsMap;
+  } catch (error) {
+    if (error?.code === 'ER_NO_SUCH_TABLE') {
+      const emptyMap = new Map();
+      TABLE_COLUMNS_CACHE.set(table, emptyMap);
+      return emptyMap;
+    }
+
+    throw error;
+  }
+}
+
+function buildSearchClause(columns, searchTerm) {
+  if (!searchTerm) {
+    return { clause: '', params: [] };
+  }
+
+  const availableColumns = SEARCHABLE_COLUMNS.map((column) => columns.get(column)).filter(Boolean);
+
+  if (availableColumns.length === 0) {
+    return { clause: '', params: [] };
+  }
+
+  const like = `%${searchTerm}%`;
+  const clause =
+    '(' +
+    availableColumns.map((column) => `COALESCE(\`${column}\`, '') LIKE ?`).join(' OR ') +
+    ')';
+  const params = new Array(availableColumns.length).fill(like);
+
+  return { clause, params };
+}
+
+function buildOrderByClause(columns) {
+  for (const column of TITLE_PREFERRED_COLUMNS) {
+    const actual = columns.get(column);
+    if (actual) {
+      return `ORDER BY (COALESCE(\`${actual}\`, '') = ''), \`${actual}\` ASC`;
+    }
+  }
+
+  for (const column of FALLBACK_ORDER_COLUMNS) {
+    const actual = columns.get(column);
+    if (actual) {
+      return `ORDER BY \`${actual}\` ASC`;
+    }
+  }
+
+  return 'ORDER BY 1';
+}
+
 function parsePossibleJson(value) {
   if (typeof value !== 'string') {
     return value;
@@ -167,22 +268,58 @@ function normalizeMediaList(value) {
   return Array.from(new Set(normalized));
 }
 
-function mapCompanyRow(row = {}) {
-  const titulo = toNullableString(row.titulo ?? row.nome ?? row.name);
-  const descricao = toNullableString(row.descricao ?? row.description ?? row.tagline);
-  const endereco = normalizeEndereco(row.endereco);
-  const celular = toNullableString(row.celular ?? row.telefone ?? row.phone ?? row.whatsapp);
-  const email = toNullableString(row.email);
-  const sala = toNullableString(row.sala ?? row.salao ?? row.room);
-  const logo = normalizeMediaUrl(row.logo ?? row.imagem ?? row.image);
-  const galeria = normalizeMediaList(
-    row.galeria ?? row.galeria_urls ?? row.gallery ?? row.galeria_de_midia ?? row.media_gallery
+function createRowValueGetter(row = {}, columns = new Map()) {
+  return (...candidates) => {
+    for (const candidate of candidates) {
+      if (!candidate) {
+        continue;
+      }
+
+      const normalized = candidate.toLowerCase();
+      const actual = columns.get(normalized) ?? candidate;
+
+      if (actual in row && row[actual] != null) {
+        return row[actual];
+      }
+
+      if (normalized !== actual && normalized in row && row[normalized] != null) {
+        return row[normalized];
+      }
+
+      if (candidate in row && row[candidate] != null) {
+        return row[candidate];
+      }
+    }
+
+    return null;
+  };
+}
+
+function mapCompanyRow(row = {}, columns = new Map()) {
+  const getValue = createRowValueGetter(row, columns);
+
+  const titulo = toNullableString(
+    getValue('titulo', 'nome', 'name', 'razao_social', 'descricao', 'description', 'tagline')
   );
-  const midia = normalizeMediaList(row.midia ?? row.midia_urls ?? row.media);
+  const descricao = toNullableString(getValue('descricao', 'description', 'tagline'));
+  const endereco = normalizeEndereco(getValue('endereco', 'address'));
+  const celular = toNullableString(getValue('celular', 'telefone', 'phone', 'whatsapp'));
+  const email = toNullableString(getValue('email'));
+  const sala = toNullableString(getValue('sala', 'salao', 'room'));
+  const logo = normalizeMediaUrl(getValue('logo', 'imagem', 'image'));
+  const galeria = normalizeMediaList(
+    getValue('galeria', 'galeria_urls', 'gallery', 'galeria_de_midia', 'media_gallery')
+  );
+  const midia = normalizeMediaList(getValue('midia', 'midia_urls', 'media'));
+
+  const pkValue = getValue('pk');
+  const id = toNullableString(getValue('id', 'slug', 'codigo', 'code'));
+  const createdAt = toNullableString(getValue('created_at', 'createdAt'));
+  const updatedAt = toNullableString(getValue('updated_at', 'updatedAt'));
 
   return {
-    pk: row.pk != null ? Number(row.pk) : null,
-    id: toNullableString(row.id ?? row.slug ?? row.codigo ?? row.code),
+    pk: pkValue != null ? Number(pkValue) : null,
+    id,
     titulo,
     descricao,
     endereco,
@@ -192,8 +329,8 @@ function mapCompanyRow(row = {}) {
     logo,
     galeria,
     midia,
-    createdAt: toNullableString(row.created_at ?? row.createdAt),
-    updatedAt: toNullableString(row.updated_at ?? row.updatedAt)
+    createdAt,
+    updatedAt
   };
 }
 
@@ -253,34 +390,45 @@ export async function listCompanies(tabela, { page = 1, pageSize = 12, q = '' } 
   const filters = [];
   const params = [];
 
+  const columns = await getTableColumns(tabela);
+
   if (searchTerm) {
-    const like = `%${searchTerm}%`;
-    filters.push(
-      "(" +
-        "COALESCE(titulo, '') LIKE ? OR " +
-        "COALESCE(descricao, '') LIKE ? OR " +
-        "COALESCE(email, '') LIKE ?" +
-      ")"
-    );
-    params.push(like, like, like);
+    const { clause, params: searchParams } = buildSearchClause(columns, searchTerm);
+    if (clause) {
+      filters.push(clause);
+      params.push(...searchParams);
+    }
   }
 
   const whereClause = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
 
-  const orderBy = "ORDER BY COALESCE(titulo, '') <> '', titulo ASC";
+  const orderBy = buildOrderByClause(columns);
   const querySql = `SELECT * FROM \`${tabela}\` ${whereClause} ${orderBy} LIMIT ? OFFSET ?`;
   const countSql = `SELECT COUNT(*) AS total FROM \`${tabela}\` ${whereClause}`;
 
-  const [rows] = await pool.query(querySql, [...params, currentPageSize, offset]);
-  const [countRows] = await pool.query(countSql, params);
-  const total = Number(countRows?.[0]?.total ?? 0);
+  try {
+    const [rows] = await pool.query(querySql, [...params, currentPageSize, offset]);
+    const [countRows] = await pool.query(countSql, params);
+    const total = Number(countRows?.[0]?.total ?? 0);
 
-  return {
-    page: currentPage,
-    pageSize: currentPageSize,
-    total,
-    items: rows.map((row) => mapCompanyRow(row))
-  };
+    return {
+      page: currentPage,
+      pageSize: currentPageSize,
+      total,
+      items: rows.map((row) => mapCompanyRow(row, columns))
+    };
+  } catch (error) {
+    if (error?.code === 'ER_NO_SUCH_TABLE') {
+      return {
+        page: currentPage,
+        pageSize: currentPageSize,
+        total: 0,
+        items: []
+      };
+    }
+
+    throw error;
+  }
 }
 
 export async function getCompany(tabela, id) {
@@ -293,6 +441,8 @@ export async function getCompany(tabela, id) {
     return null;
   }
 
+  const columns = await getTableColumns(tabela);
+
   const [rows] = await pool.query(
     `SELECT * FROM \`${tabela}\` WHERE id = ? OR pk = ? LIMIT 1`,
     [identifier, identifier]
@@ -302,6 +452,15 @@ export async function getCompany(tabela, id) {
     return null;
   }
 
-  return mapCompanyRow(rows[0]);
+  return mapCompanyRow(rows[0], columns);
 }
+
+export const __internal = {
+  buildOrderByClause,
+  buildSearchClause,
+  mapCompanyRow,
+  clearTableColumnsCache() {
+    TABLE_COLUMNS_CACHE.clear();
+  }
+};
 

--- a/backend/test/categories-helpers.test.js
+++ b/backend/test/categories-helpers.test.js
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __internal } from '../db/categories.js';
+
+const { buildSearchClause, buildOrderByClause, mapCompanyRow } = __internal;
+
+test('buildSearchClause uses available searchable columns', () => {
+  const columns = new Map([
+    ['titulo', 'titulo'],
+    ['email', 'email']
+  ]);
+
+  const { clause, params } = buildSearchClause(columns, 'teste');
+
+  assert.equal(clause, "(COALESCE(`titulo`, '') LIKE ? OR COALESCE(`email`, '') LIKE ?)");
+  assert.deepEqual(params, ['%teste%', '%teste%']);
+});
+
+test('buildSearchClause returns empty clause when nothing matches', () => {
+  const columns = new Map([
+    ['id', 'id']
+  ]);
+
+  const { clause, params } = buildSearchClause(columns, 'teste');
+
+  assert.equal(clause, '');
+  assert.deepEqual(params, []);
+});
+
+test('buildSearchClause ignores empty search terms', () => {
+  const columns = new Map([
+    ['titulo', 'titulo']
+  ]);
+
+  const { clause, params } = buildSearchClause(columns, '');
+
+  assert.equal(clause, '');
+  assert.deepEqual(params, []);
+});
+
+test('buildOrderByClause prefers textual columns', () => {
+  const columns = new Map([
+    ['nome', 'Nome'],
+    ['id', 'id']
+  ]);
+
+  assert.equal(
+    buildOrderByClause(columns),
+    "ORDER BY (COALESCE(`Nome`, '') = ''), `Nome` ASC"
+  );
+});
+
+test('buildOrderByClause falls back to identifiers', () => {
+  const columns = new Map([
+    ['id', 'id']
+  ]);
+
+  assert.equal(buildOrderByClause(columns), 'ORDER BY `id` ASC');
+});
+
+test('buildOrderByClause returns default ordering when nothing matches', () => {
+  const columns = new Map();
+
+  assert.equal(buildOrderByClause(columns), 'ORDER BY 1');
+});
+
+test('mapCompanyRow reads values regardless of column casing', () => {
+  const columns = new Map([
+    ['titulo', 'Titulo'],
+    ['descricao', 'Descricao'],
+    ['pk', 'PK']
+  ]);
+
+  const row = {
+    Titulo: 'Advocacia Alfa',
+    Descricao: 'Atendimento jurídico especializado',
+    PK: '7'
+  };
+
+  const mapped = mapCompanyRow(row, columns);
+
+  assert.equal(mapped.titulo, 'Advocacia Alfa');
+  assert.equal(mapped.descricao, 'Atendimento jurídico especializado');
+  assert.equal(mapped.pk, 7);
+});


### PR DESCRIPTION
## Summary
- cache company table column metadata to build safe search/order clauses and avoid querying missing fields
- return empty results instead of 500s when a category table is absent and reuse new helpers
- add unit tests covering the clause builders used by the listing logic
- map company rows using introspected column names so titles render even when database columns have different casing, with a unit test covering the regression

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e4631c5e9083309cbe6722a8d922ed