### PR TITLE
Fix categories listing helper regression

### DIFF
--- a/backend/db/categories.js
+++ b/backend/db/categories.js
@@ -415,11 +415,7 @@ export async function listCompanies(tabela, { page = 1, pageSize = 12, q = '' } 
       page: currentPage,
       pageSize: currentPageSize,
       total,
-
       items: rows.map((row) => mapCompanyRow(row, columns))
-
-      items: rows.map((row) => mapCompanyRow(row))
-
     };
   } catch (error) {
     if (error?.code === 'ER_NO_SUCH_TABLE') {
@@ -462,9 +458,7 @@ export async function getCompany(tabela, id) {
 export const __internal = {
   buildOrderByClause,
   buildSearchClause,
-
   mapCompanyRow,
-
   clearTableColumnsCache() {
     TABLE_COLUMNS_CACHE.clear();
   }

--- a/backend/test/categories-helpers.test.js
+++ b/backend/test/categories-helpers.test.js
@@ -3,10 +3,7 @@ import assert from 'node:assert/strict';
 
 import { __internal } from '../db/categories.js';
 
-
 const { buildSearchClause, buildOrderByClause, mapCompanyRow } = __internal;
-
-const { buildSearchClause, buildOrderByClause } = __internal;
 
 
 test('buildSearchClause uses available searchable columns', () => {


### PR DESCRIPTION
## Summary
- remove duplicated `items` assignment from `listCompanies` results to restore valid JSON responses
- tidy the `__internal` helper export and test imports to avoid duplicate declarations

## Testing
- npm --prefix backend test
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e46c2bf30c83309d758e32c79b7587