### PR TITLE
Fix advocacy category routing for duplicated slugs

### DIFF
--- a/frontend/src/lib/categories.ts
+++ b/frontend/src/lib/categories.ts
@@ -23,11 +23,24 @@ export function normalizeCategorySlug(value?: string | number | null) {
   }
 
   const withoutDiacritics = stringValue.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-  const sanitized = withoutDiacritics
+  let sanitized = withoutDiacritics
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '_')
     .replace(/_+/g, '_')
     .replace(/^_|_$/g, '');
+
+  if (!sanitized) {
+    return '';
+  }
+
+  const duplicateSuffixPattern = /(?:_+\d+)+$/;
+  if (duplicateSuffixPattern.test(sanitized)) {
+    const withoutSuffix = sanitized.replace(duplicateSuffixPattern, '');
+
+    if (withoutSuffix && LINKED_CATEGORY_SET.has(withoutSuffix)) {
+      sanitized = withoutSuffix;
+    }
+  }
 
   return sanitized;
 }


### PR DESCRIPTION
## Summary
- normalize category slugs with numeric duplicate suffixes so legacy paths such as "advocacia-1" resolve to the correct category
- rely on the known category list to collapse duplicated suffixes while keeping other slugs unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e58edd36208330941257c3e9fec11b