### PR TITLE
Fix advocacy category routing and title mapping

### DIFF
--- a/backend/db/categories.js
+++ b/backend/db/categories.js
@@ -18,6 +18,7 @@ const TABLE_COLUMNS_CACHE = new Map();
 
 const SEARCHABLE_COLUMNS = [
   'titulo',
+  'title',
   'nome',
   'name',
   'razao_social',
@@ -32,6 +33,7 @@ const SEARCHABLE_COLUMNS = [
 
 const TITLE_PREFERRED_COLUMNS = [
   'titulo',
+  'title',
   'nome',
   'name',
   'razao_social',
@@ -299,7 +301,7 @@ function mapCompanyRow(row = {}, columns = new Map()) {
   const getValue = createRowValueGetter(row, columns);
 
   const titulo = toNullableString(
-    getValue('titulo', 'nome', 'name', 'razao_social', 'descricao', 'description', 'tagline')
+    getValue('titulo', 'title', 'nome', 'name', 'razao_social', 'descricao', 'description', 'tagline')
   );
   const descricao = toNullableString(getValue('descricao', 'description', 'tagline'));
   const endereco = normalizeEndereco(getValue('endereco', 'address'));

--- a/backend/test/categories-helpers.test.js
+++ b/backend/test/categories-helpers.test.js
@@ -52,6 +52,18 @@ test('buildOrderByClause prefers textual columns', () => {
   );
 });
 
+test('buildOrderByClause prefers title column before identifiers', () => {
+  const columns = new Map([
+    ['title', 'title'],
+    ['id', 'id']
+  ]);
+
+  assert.equal(
+    buildOrderByClause(columns),
+    "ORDER BY (COALESCE(`title`, '') = ''), `title` ASC"
+  );
+});
+
 test('buildOrderByClause falls back to identifiers', () => {
   const columns = new Map([
     ['id', 'id']
@@ -85,5 +97,22 @@ test('mapCompanyRow reads values regardless of column casing', () => {
   assert.equal(mapped.titulo, 'Advocacia Alfa');
   assert.equal(mapped.descricao, 'Atendimento jurídico especializado');
   assert.equal(mapped.pk, 7);
+});
+
+test('mapCompanyRow prefers title column for company name when titulo is unavailable', () => {
+  const columns = new Map([
+    ['title', 'title'],
+    ['descricao', 'descricao']
+  ]);
+
+  const row = {
+    title: 'Advocacia Beta',
+    descricao: 'Escritório especializado em direito civil'
+  };
+
+  const mapped = mapCompanyRow(row, columns);
+
+  assert.equal(mapped.titulo, 'Advocacia Beta');
+  assert.equal(mapped.descricao, 'Escritório especializado em direito civil');
 });
 

--- a/frontend/src/lib/categories.ts
+++ b/frontend/src/lib/categories.ts
@@ -23,11 +23,24 @@ export function normalizeCategorySlug(value?: string | number | null) {
   }
 
   const withoutDiacritics = stringValue.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-  const sanitized = withoutDiacritics
+  let sanitized = withoutDiacritics
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '_')
     .replace(/_+/g, '_')
     .replace(/^_|_$/g, '');
+
+  if (!sanitized) {
+    return '';
+  }
+
+  const duplicateSuffixPattern = /(?:_+\d+)+$/;
+  if (duplicateSuffixPattern.test(sanitized)) {
+    const withoutSuffix = sanitized.replace(duplicateSuffixPattern, '');
+
+    if (withoutSuffix && LINKED_CATEGORY_SET.has(withoutSuffix)) {
+      sanitized = withoutSuffix;
+    }
+  }
 
   return sanitized;
 }


### PR DESCRIPTION
## Summary
- normalize category slugs with numeric duplicate suffixes so legacy paths such as "advocacia-1" resolve to the correct category
- include the `title` column when resolving company names, searches, and ordering so advocacy listings show their correct titles
- extend backend tests to cover the new title handling logic

## Testing
- npm --prefix backend test
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e58edd36208330941257c3e9fec11b