### PR TITLE
docs: document presentation assets folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Este projeto reúne o backend Express e o frontend React/Vite do site institucio
 
 - `backend/`: API Node.js/Express que acessa MySQL via `mysql2/promise`, gera sitemaps e orquestra o build do frontend.
 - `frontend/`: SPA em React com React Router, TanStack Query, Tailwind CSS e provedores globais (toasts, SEO).
+- `frontend/public/presentation-assets/`: Pasta para imagens e documentos usados em apresentações corporativas.
 - `scripts/` e `deploy/`: utilitários de build, sincronização e automação de deploy.
 
 ## Variáveis de ambiente

--- a/frontend/public/presentation-assets/README.md
+++ b/frontend/public/presentation-assets/README.md
@@ -1,0 +1,15 @@
+# Assets de apresentações corporativas
+
+Use esta pasta para armazenar imagens, PDFs e outros arquivos estáticos que serão utilizados em apresentações para empresas. Todos os arquivos aqui dentro são servidos pelo Vite/Express a partir de `/presentation-assets`, facilitando o consumo direto no frontend.
+
+## Boas práticas
+
+- Crie subpastas quando necessário (por exemplo, `logotipos/`, `mockups/`, `cases/`).
+- Nomeie os arquivos utilizando *kebab-case* e descrevendo o conteúdo (ex.: `fachada-centro-comercial.jpg`).
+- Otimize as imagens antes de adicioná-las para reduzir o tamanho do build.
+- Atualize os componentes ou páginas que consomem esses arquivos para apontar para `/presentation-assets/<arquivo>`.
+- Quando remover um arquivo do código, apague-o desta pasta para evitar ativos órfãos.
+
+## Versionamento
+
+Esta pasta faz parte do repositório. Sempre que adicionar ou remover arquivos relevantes às apresentações, inclua as alterações no commit para manter o histórico atualizado.


### PR DESCRIPTION
## Summary
- create a `frontend/public/presentation-assets` directory with guidance on storing presentation files
- mention the new directory in the repository structure overview

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e596425e948330b4af1bc23bee6536