### PR TITLE
Expose runtime diagnostics in health API

### DIFF
--- a/backend/db/categories.js
+++ b/backend/db/categories.js
@@ -301,12 +301,6 @@ function createRowValueGetter(row = {}, columns = new Map()) {
 function mapCompanyRow(row = {}, columns = new Map()) {
   const getValue = createRowValueGetter(row, columns);
 
-
-
-  const titulo = toNullableString(
-    getValue('titulo', 'title', 'nome', 'name', 'razao_social', 'descricao', 'description', 'tagline')
-  );
-
   const descricao = toNullableString(getValue('descricao', 'description', 'tagline'));
   const tituloDireto = toNullableString(getValue('titulo'));
   const tituloAlternativo = toNullableString(getValue('title', 'nome', 'name', 'razao_social'));

--- a/backend/src/rotas/health.js
+++ b/backend/src/rotas/health.js
@@ -2,6 +2,75 @@ import { Router } from 'express';
 import { CATEGORIES } from './companies.js';
 import pool, { ping } from '../../db/pool.js';
 
+function summarizeActiveEntries(getter) {
+  if (typeof getter !== 'function') {
+    return { total: 0, byType: {} };
+  }
+
+  const entries = getter();
+  if (!entries) {
+    return { total: 0, byType: {} };
+  }
+
+  const list = Array.isArray(entries)
+    ? entries
+    : typeof entries[Symbol.iterator] === 'function'
+      ? Array.from(entries)
+      : [];
+
+  const byType = list.reduce((accumulator, entry) => {
+    const type = entry?.constructor?.name || 'Unknown';
+    accumulator[type] = (accumulator[type] || 0) + 1;
+    return accumulator;
+  }, {});
+
+  return { total: list.length, byType };
+}
+
+function normalizeResourceUsage(details) {
+  if (!details || typeof details !== 'object') {
+    return null;
+  }
+
+  const {
+    userCPUTime,
+    systemCPUTime,
+    maxRSS,
+    sharedMemorySize,
+    unsharedDataSize,
+    unsharedStackSize,
+    minorPageFault,
+    majorPageFault,
+    voluntaryContextSwitches,
+    involuntaryContextSwitches,
+    fsRead,
+    fsWrite,
+    ipcSent,
+    ipcReceived,
+    signalsCount,
+    swapCount
+  } = details;
+
+  return {
+    userCPUTime,
+    systemCPUTime,
+    maxRSS,
+    sharedMemorySize,
+    unsharedDataSize,
+    unsharedStackSize,
+    minorPageFault,
+    majorPageFault,
+    voluntaryContextSwitches,
+    involuntaryContextSwitches,
+    fsRead,
+    fsWrite,
+    ipcSent,
+    ipcReceived,
+    signalsCount,
+    swapCount
+  };
+}
+
 const router = Router();
 
 router.get('/health', (req, res) => {
@@ -12,6 +81,40 @@ router.get('/health', (req, res) => {
       USE_JSON_DB: process.env.USE_JSON_DB ?? null,
       NODE_ENV: process.env.NODE_ENV ?? null
     }
+  });
+});
+
+router.get('/health/processes', (req, res) => {
+  const memory = process.memoryUsage();
+  const cpu = process.cpuUsage();
+  const resourceUsage = typeof process.resourceUsage === 'function'
+    ? process.resourceUsage()
+    : null;
+
+  const handles = summarizeActiveEntries(process._getActiveHandles);
+  const requests = summarizeActiveEntries(process._getActiveRequests);
+
+  res.json({
+    pid: process.pid,
+    ppid: process.ppid,
+    uptime: process.uptime(),
+    platform: process.platform,
+    arch: process.arch,
+    memory: {
+      rss: memory.rss,
+      heapTotal: memory.heapTotal,
+      heapUsed: memory.heapUsed,
+      external: memory.external,
+      arrayBuffers: memory.arrayBuffers
+    },
+    cpu: {
+      user: cpu.user,
+      system: cpu.system
+    },
+    resourceUsage: normalizeResourceUsage(resourceUsage),
+    handles,
+    requests,
+    versions: process.versions
   });
 });
 

--- a/backend/test/health-route.test.js
+++ b/backend/test/health-route.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import express from 'express';
+import request from 'supertest';
+
+import healthRouter from '../src/rotas/health.js';
+
+const createApp = () => {
+  const app = express();
+  app.use('/api', healthRouter);
+  return app;
+};
+
+test('GET /api/health/processes returns runtime diagnostics', async () => {
+  const response = await request(createApp()).get('/api/health/processes');
+
+  assert.equal(response.status, 200);
+
+  const body = response.body;
+
+  assert.equal(typeof body.pid, 'number');
+  assert.equal(typeof body.ppid, 'number');
+  assert.equal(typeof body.uptime, 'number');
+  assert.equal(typeof body.platform, 'string');
+  assert.equal(typeof body.arch, 'string');
+
+  assert.equal(typeof body.memory, 'object');
+  assert.equal(typeof body.memory.heapUsed, 'number');
+  assert.equal(typeof body.memory.heapTotal, 'number');
+
+  assert.equal(typeof body.cpu, 'object');
+  assert.equal(typeof body.cpu.user, 'number');
+  assert.equal(typeof body.cpu.system, 'number');
+
+  assert.equal(typeof body.handles.total, 'number');
+  assert.equal(typeof body.handles.byType, 'object');
+  assert.equal(typeof body.requests.total, 'number');
+  assert.equal(typeof body.requests.byType, 'object');
+
+  assert.ok(body.versions);
+  assert.equal(typeof body.versions.node, 'string');
+
+  assert.ok(Object.prototype.hasOwnProperty.call(body, 'resourceUsage'));
+});


### PR DESCRIPTION
## Summary
- add a `/api/health/processes` endpoint that reports runtime metrics and active handle summaries
- ensure resource usage details are serialized safely for the diagnostics payload
- remove a duplicate `titulo` declaration in the categories repository and cover the new endpoint with a regression test

## Testing
- npm --prefix backend test
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e59be741148330b9755a4ffda7c298