### PR TITLE
Fix home page sector card layout

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -93,8 +93,6 @@ const quickInfoCards: QuickInfoCard[] = [
   }
 ];
 
-const categoriesWithFacadeImage = new Set(['imobiliaria', 'industrias', 'lojas', 'saude', 'servicos_publicos']);
-
 type CategoryCard = {
   slug: string;
   title: string;
@@ -213,7 +211,7 @@ export default function HomePage() {
       title: meta.title ?? category.label,
       description: meta.description,
       companiesLabel: formatCompaniesLabel(category.total),
-      image: meta.image,
+      image: meta.image ?? DEFAULT_CATEGORY_IMAGE,
       href: `/empresas/${category.slug}`
     };
   });
@@ -350,14 +348,10 @@ export default function HomePage() {
 
           <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
             {categoryCards.map((card) => {
-              const shouldDisplayFacadeImage = categoriesWithFacadeImage.has(card.slug);
-
-              const displayedImage = shouldDisplayFacadeImage ? '/Fachada.jpg' : card.image;
-
               return (
                 <article key={card.slug} className="flex h-full flex-col overflow-hidden rounded-3xl bg-white shadow-lg">
                   <div className="relative h-44 w-full overflow-hidden">
-                    <img src={displayedImage} alt={card.title} className="h-full w-full object-cover" />
+                    <img src={card.image} alt={card.title} className="h-full w-full object-cover" />
                     <span className="absolute left-4 top-4 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-primary-700">
                       {card.companiesLabel}
                     </span>
@@ -366,17 +360,6 @@ export default function HomePage() {
                     <div className="flex-1 space-y-3">
                       <h3 className="text-xl font-semibold text-primary-800">{card.title}</h3>
                       <p className="text-sm text-[#4f5d55]">{card.description}</p>
-
-                      {shouldDisplayFacadeImage && (
-                        <figure className="overflow-hidden rounded-2xl border border-primary-100">
-                          <img
-                            src="/Fachada.jpg"
-                            alt="Fachada do Jaguar Center Plaza"
-                            className="h-32 w-full object-cover"
-                          />
-                        </figure>
-                      )}
-
                     </div>
                     <Link
                       to={card.href}


### PR DESCRIPTION
## Summary
- remove facade-specific handling from the home page sector cards so every card shares the same structure
- ensure category images always fall back to the default asset when metadata is missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5b3717a608330ae50ca4290d622c1