### PR TITLE
Ensure industry category and update home contact details

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -16,7 +16,7 @@ export default function Header() {
   const query = useQuery({ queryKey: ['areas'], queryFn: fetchAreas });
   const areas = query.data?.items ?? [];
   const categoryLinks = useMemo(() => {
-    return areas
+    const links = areas
       .map((item) => {
         const slug = normalizeCategorySlug(item.slug ?? item.id ?? null);
 
@@ -30,6 +30,12 @@ export default function Header() {
         };
       })
       .filter((item): item is { slug: string; label: string } => item !== null);
+
+    if (!links.some((item) => item.slug === 'industrias')) {
+      links.push({ slug: 'industrias', label: 'Indústrias' });
+    }
+
+    return links;
   }, [areas]);
 
   return (

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -71,17 +71,17 @@ const quickInfoCards: QuickInfoCard[] = [
       <div className="space-y-1 text-sm font-medium text-white">
         <p>
           <span className="text-white/80">Telefone:</span>{' '}
-          <a href="tel:+551938373391" className="underline decoration-white/40 underline-offset-2 hover:text-white">
-            (19) 3837-3391
+          <a href="tel:+551938335600" className="underline decoration-white/40 underline-offset-2 hover:text-white">
+            (19) 3833-5600
           </a>
         </p>
         <p>
           <span className="text-white/80">E-mail:</span>{' '}
           <a
-            href="mailto:jaguarcenterplaza@hotmail.com"
+            href="mailto:contato@jaguarcenterplaza.com.br"
             className="underline decoration-white/40 underline-offset-2 hover:text-white"
           >
-            jaguarcenterplaza@hotmail.com
+            contato@jaguarcenterplaza.com.br
           </a>
         </p>
       </div>


### PR DESCRIPTION
## Summary
- ensure the header categories list always includes the Indústrias link even when missing from the API response
- update the home quick info card to display the current phone number and email address

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5b7738f3c8330a6d5a2b3c6984dc6