### PR TITLE
Atualiza informações de contato exibidas na home

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -59,11 +59,11 @@ export default function Header() {
             </span>
           </div>
           <div className="flex items-center gap-4">
-            <a href="tel:+551938335600" className="font-semibold text-accent-100 hover:text-white">
-              (19) 3833-5600
+            <a href="tel:+551938373391" className="font-semibold text-accent-100 hover:text-white">
+              (19) 3837-3391
             </a>
-            <a href="mailto:contato@jaguarcenterplaza.com.br" className="hidden font-medium text-accent-100 hover:text-white md:inline">
-              contato@jaguarcenterplaza.com.br
+            <a href="mailto:jaguarcenterplaza@hotmail.com" className="hidden font-medium text-accent-100 hover:text-white md:inline">
+              jaguarcenterplaza@hotmail.com
             </a>
           </div>
         </Container>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -66,28 +66,6 @@ const quickInfoCards: QuickInfoCard[] = [
     content: <p className="text-sm font-medium text-white">Seg. a sex. das 7h às 21h · Sáb. das 8h às 14h</p>
   },
   {
-    label: 'Contato',
-    content: (
-      <div className="space-y-1 text-sm font-medium text-white">
-        <p>
-          <span className="text-white/80">Telefone:</span>{' '}
-          <a href="tel:+551938335600" className="underline decoration-white/40 underline-offset-2 hover:text-white">
-            (19) 3833-5600
-          </a>
-        </p>
-        <p>
-          <span className="text-white/80">E-mail:</span>{' '}
-          <a
-            href="mailto:contato@jaguarcenterplaza.com.br"
-            className="underline decoration-white/40 underline-offset-2 hover:text-white"
-          >
-            contato@jaguarcenterplaza.com.br
-          </a>
-        </p>
-      </div>
-    )
-  },
-  {
     label: 'Endereço',
     content: <p className="text-sm font-medium text-white">Rua Cândido Bueno, 1299 · Centro · Jaguariúna/SP</p>
   }
@@ -249,7 +227,7 @@ export default function HomePage() {
                 Agende uma visita
               </Link>
             </div>
-            <div className="grid gap-4 pt-4 sm:grid-cols-3">
+            <div className="grid gap-4 pt-4 sm:grid-cols-2">
               {quickInfoCards.map((card) => (
                 <div key={card.label} className="rounded-2xl bg-white/15 p-4">
                   <p className="text-xs font-semibold uppercase tracking-wide text-accent-100">{card.label}</p>


### PR DESCRIPTION
## Summary
- atualiza o telefone e o e-mail exibidos na faixa superior do cabeçalho para os novos contatos
- remove o cartão de contato da seção hero da home e ajusta o grid para manter o layout equilibrado

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5b8dc8a38833097d6bd2913021a60